### PR TITLE
add examples to instrument RustyHermit applications

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
       run:
          cargo build -p rusty_demo -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
     - name: Building release version (LTO)
+      run:
          cargo build -p rusty_demo --profile release-lto -Z unstable-options -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
       env:
          RUSTFLAGS: -Clinker-plugin-lto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
       run:
          cargo build -p rusty_demo -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
     - name: Building release version (LTO)
-         cargo build -p rusty_demo --profile release-lto -Z unstable-options
+         cargo build -p rusty_demo --profile release-lto -Z unstable-options -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
       env:
          RUSTFLAGS: -Clinker-plugin-lto
     - name: Build loader (unix)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,6 @@ jobs:
     - name: Building release version
       run:
          cargo build -p rusty_demo -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
-      env:
-         RUSTFLAGS: -Clinker-plugin-lto
     - name: Build loader (unix)
       working-directory: loader
       run: make

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,10 @@ jobs:
     - name: Building release version
       run:
          cargo build -p rusty_demo -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
+    - name: Building release version (LTO)
+         cargo build -p rusty_demo --profile release-lto -Z unstable-options
+      env:
+         RUSTFLAGS: -Clinker-plugin-lto
     - name: Build loader (unix)
       working-directory: loader
       run: make
@@ -96,6 +100,9 @@ jobs:
     - name: Test release version
       run:
          qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+    - name: Test release version (LTO)
+      run:
+         qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release-lto/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
     - name: Build httpd with DHCP support
       run:
          cargo build --manifest-path examples/httpd/Cargo.toml --features dhcpv4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,15 @@ variables:
 prepare:docker:
   <<: *prepare_docker
 
+build:instrument:
+  stage: build
+  image: ${CI_REGISTRY_IMAGE}
+  script:
+    - RUSTFLAGS="-Z instrument-mcount" cargo build -p rusty_demo --release --features=instrument
+  artifacts:
+    paths:
+      - target/x86_64-unknown-hermit/release/matrix_multiplcation
+
 build:demo:
   stage: build
   image: ${CI_REGISTRY_IMAGE}
@@ -54,6 +63,19 @@ build:httpd:
   artifacts:
     paths:
       - target/x86_64-unknown-hermit/release/httpd
+
+test:instrument:
+   stage: test
+   dependencies:
+     - build:instrument
+   image: ${CI_REGISTRY_IMAGE}
+   script:
+     - lscpu
+     - kvm-ok
+     - cargo install uhyve
+     - uhyve -v -c 1 target/x86_64-unknown-hermit/release/matrix_multiplcation
+   tags:
+     - privileged
 
 test:uhyve:
    stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,10 +39,12 @@ build:demo:
   script:
     - cargo build -p rusty_demo
     - cargo build -p rusty_demo --release
+    - RUSTFLAGS="-Clinker-plugin-lto" cargo build -p rusty_demo --profile release-lto -Z unstable-options
   artifacts:
     paths:
       - target/x86_64-unknown-hermit/debug/rusty_demo
       - target/x86_64-unknown-hermit/release/rusty_demo
+      - target/x86_64-unknown-hermit/release-lto/rusty_demo
 
 build:httpd:
   stage: build
@@ -66,6 +68,8 @@ test:uhyve:
      - uhyve -v -c 2 target/x86_64-unknown-hermit/debug/rusty_demo
      - uhyve -v -c 1 target/x86_64-unknown-hermit/release/rusty_demo
      - uhyve -v -c 2 target/x86_64-unknown-hermit/release/rusty_demo
+     - uhyve -v -c 1 target/x86_64-unknown-hermit/release-lto/rusty_demo
+     - uhyve -v -c 2 target/x86_64-unknown-hermit/release-lto/rusty_demo
    tags:
      - privileged
 
@@ -85,6 +89,8 @@ test:qemu:
      - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand -enable-kvm
      - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/release/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand -enable-kvm
      - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/release/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand -enable-kvm
+     - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/release/rusty-loader -initrd target/x86_64-unknown-hermit/release-lto/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand -enable-kvm
+     - qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/release/rusty-loader -initrd target/x86_64-unknown-hermit/release-lto/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand -enable-kvm
    tags:
      - privileged
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ build:demo:
   image: ${CI_REGISTRY_IMAGE}
   script:
     - cargo build -p rusty_demo
-    - RUSTFLAGS="-Clinker-plugin-lto" cargo build -p rusty_demo --release
+    - cargo build -p rusty_demo --release
   artifacts:
     paths:
       - target/x86_64-unknown-hermit/debug/rusty_demo
@@ -48,7 +48,7 @@ build:httpd:
   stage: build
   image: ${CI_REGISTRY_IMAGE}
   script:
-    - RUSTFLAGS="-Clinker-plugin-lto" cargo build --manifest-path examples/httpd/Cargo.toml --no-default-features --features pci,acpi,smoltcp,vga,dhcpv4 --release
+    - cargo build --manifest-path examples/httpd/Cargo.toml --no-default-features --features pci,acpi,smoltcp,vga,dhcpv4 --release
   artifacts:
     paths:
       - target/x86_64-unknown-hermit/release/httpd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ name = "hello_world"
 version = "0.1.0"
 dependencies = [
  "hermit-sys",
+ "rftrace-frontend",
 ]
 
 [[package]]
@@ -656,6 +657,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2ee2d77e97cb948eb4576a5b7908aac75c02afa337c99aa34b9cef0346bedd"
 
 [[package]]
+name = "rftrace-frontend"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419a5a276d688261074e7356d4061628dca7b0987f9422eeed4c66ecc128639a"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "rust-tcp-io-perf"
 version = "0.0.0"
 dependencies = [
@@ -689,6 +699,7 @@ dependencies = [
  "hermit-sys",
  "num_cpus",
  "rayon",
+ "rftrace-frontend",
  "syscalls",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["target", "loader", "libhermit-rs"]
 opt-level = 3
 debug = false
 rpath = false
-lto = "thin"
+lto = false
 debug-assertions = false
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["named-profiles"]
 [workspace]
 members = [
     "hermit-abi",
@@ -16,6 +17,10 @@ debug = false
 rpath = false
 lto = false
 debug-assertions = false
+
+[profile.release-lto]
+inherits = "release"
+lto = "thin"
 
 [profile.dev]
 opt-level = 1      # controls the `--opt-level` the compiler builds with

--- a/benches/micro/Cargo.toml
+++ b/benches/micro/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["named-profiles"]
 [package]
 name = "micro_benchmarks"
 version = "0.1.0"
@@ -34,6 +35,10 @@ debug = false
 rpath = false
 lto = false
 debug-assertions = false
+
+[profile.release-lto]
+inherits = "release"
+lto = "thin"
 
 [profile.dev]
 opt-level = 1      # controls the `--opt-level` the compiler builds with

--- a/benches/micro/Cargo.toml
+++ b/benches/micro/Cargo.toml
@@ -27,13 +27,12 @@ pci = ["hermit-sys/pci"]
 acpi = ["hermit-sys/acpi"]
 fsgsbase = ["hermit-sys/fsgsbase"]
 smp = ["hermit-sys/smp"]
-instrument = ["hermit-sys/instrument"]
 
 [profile.release]
 opt-level = 3
 debug = false
 rpath = false
-lto = true
+lto = false
 debug-assertions = false
 
 [profile.dev]

--- a/benches/micro/rust-toolchain
+++ b/benches/micro/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/benches/netbench/Cargo.toml
+++ b/benches/netbench/Cargo.toml
@@ -1,10 +1,9 @@
+cargo-features = ["named-profiles"]
 [package]
-
 name = "rust-tcp-io-perf"
 version = "0.0.0"
 authors = ["Lorenzo Martini <lmartini@student.ethz.ch>"]
 readme = "README.md"
-
 description = "A Rust program to measure bandwidth or latency over a Rust TCP connection"
 
 [dependencies]
@@ -48,8 +47,12 @@ path = "src/rust-tcp-latency/client.rs"
 opt-level = 3
 debug = false
 rpath = false
-lto = true
+lto = false
 debug-assertions = false
+
+[profile.release-lto]
+inherits = "release"
+lto = "thin"
 
 [profile.dev]
 opt-level = 1      # controls the `--opt-level` the compiler builds with

--- a/benches/netbench/Cargo.toml
+++ b/benches/netbench/Cargo.toml
@@ -27,7 +27,6 @@ acpi = ["hermit-sys/acpi"]
 fsgsbase = ["hermit-sys/fsgsbase"]
 smp = ["hermit-sys/smp"]
 smoltcp = ["hermit-sys/smoltcp"]
-instrument = ["hermit-sys/instrument"]
 
 [[bin]]
 name = "server-bw"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -33,6 +33,10 @@ default-features = false
 [target.'cfg(target_os = "linux")'.dependencies]
 syscalls = { version = "0.2", default-features = false }
 
+[dependencies.rftrace-frontend]
+version = "0.1.0"
+optional = true
+
 [features]
 default = ["pci", "acpi", "smp"]
 vga = ["hermit-sys/vga"]
@@ -40,13 +44,13 @@ pci = ["hermit-sys/pci"]
 acpi = ["hermit-sys/acpi"]
 fsgsbase = ["hermit-sys/fsgsbase"]
 smp = ["hermit-sys/smp"]
-instrument = ["hermit-sys/instrument"]
+instrument = ["hermit-sys/instrument", "rftrace-frontend"]
 
 [profile.release]
 opt-level = 3
 debug = false
 rpath = false
-lto = true
+lto = false
 debug-assertions = false
 
 [profile.dev]

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["named-profiles"]
 [package]
 name = "rusty_demo"
 version = "0.1.0"
@@ -52,6 +53,10 @@ debug = false
 rpath = false
 lto = false
 debug-assertions = false
+
+[profile.release-lto]
+inherits = "release"
+lto = "thin"
 
 [profile.dev]
 opt-level = 1      # controls the `--opt-level` the compiler builds with

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -13,12 +13,16 @@
 extern crate hermit_sys;
 extern crate num_cpus;
 extern crate rayon;
+#[cfg(feature = "instrument")]
+extern crate rftrace_frontend;
 #[cfg(target_os = "linux")]
 #[macro_use]
 extern crate syscalls;
 
 mod tests;
 
+#[cfg(feature = "instrument")]
+use rftrace_frontend::Events;
 use tests::*;
 
 fn test_result<T>(result: Result<(), T>) -> &'static str {
@@ -29,6 +33,11 @@ fn test_result<T>(result: Result<(), T>) -> &'static str {
 }
 
 fn main() {
+	#[cfg(feature = "instrument")]
+	let events = rftrace_frontend::init(1000000, true);
+	#[cfg(feature = "instrument")]
+	rftrace_frontend::enable();
+
 	println!("Test {} ... {}", stringify!(hello), test_result(hello()));
 	println!(
 		"Test {} ... {}",
@@ -85,4 +94,8 @@ fn main() {
 		stringify!(thread_creation),
 		test_result(thread_creation())
 	);
+
+	#[cfg(feature = "instrument")]
+	rftrace_frontend::dump_full_uftrace(events, "trace", "rusty_demo", false)
+		.expect("Saving trace failed");
 }

--- a/examples/demo/src/matrix_multiplication.rs
+++ b/examples/demo/src/matrix_multiplication.rs
@@ -13,12 +13,16 @@
 extern crate hermit_sys;
 extern crate num_cpus;
 extern crate rayon;
+#[cfg(feature = "instrument")]
+extern crate rftrace_frontend;
 #[cfg(target_os = "linux")]
 #[macro_use]
 extern crate syscalls;
 
 mod tests;
 
+#[cfg(feature = "instrument")]
+use rftrace_frontend::Events;
 use tests::*;
 
 fn test_result<T>(result: Result<(), T>) -> &'static str {
@@ -29,9 +33,18 @@ fn test_result<T>(result: Result<(), T>) -> &'static str {
 }
 
 fn main() {
+	#[cfg(feature = "instrument")]
+	let events = rftrace_frontend::init(1000000, true);
+	#[cfg(feature = "instrument")]
+	rftrace_frontend::enable();
+
 	println!(
 		"Test {} ... {}",
 		stringify!(test_matmul_strassen),
 		test_result(test_matmul_strassen())
 	);
+
+	#[cfg(feature = "instrument")]
+	rftrace_frontend::dump_full_uftrace(events, "trace", "matrix_multiplcation", false)
+		.expect("Saving trace failed");
 }

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["named-profiles"]
 [package]
 name = "hello_world"
 version = "0.1.0"
@@ -29,6 +30,10 @@ debug = false
 rpath = false
 lto = true
 debug-assertions = false
+
+[profile.release-lto]
+inherits = "release"
+lto = "thin"
 
 [profile.dev]
 opt-level = 1      # controls the `--opt-level` the compiler builds with

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -10,6 +10,10 @@ path = "../../hermit-sys"
 default-features = false
 features = ["with_submodule"]
 
+[dependencies.rftrace-frontend]
+version = "0.1.0"
+optional = true
+
 [features]
 default = ["pci", "acpi"]
 vga = ["hermit-sys/vga"]
@@ -17,7 +21,7 @@ pci = ["hermit-sys/pci"]
 acpi = ["hermit-sys/acpi"]
 fsgsbase = ["hermit-sys/fsgsbase"]
 smp = ["hermit-sys/smp"]
-instrument = ["hermit-sys/instrument"]
+instrument = ["hermit-sys/instrument", "rftrace-frontend"]
 
 [profile.release]
 opt-level = 3

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,7 +3,18 @@
 
 #[cfg(target_os = "hermit")]
 extern crate hermit_sys;
+#[cfg(feature = "instrument")]
+extern crate rftrace_frontend;
 
 fn main() {
+	#[cfg(feature = "instrument")]
+	let events = rftrace_frontend::init(1000000, true);
+	#[cfg(feature = "instrument")]
+	rftrace_frontend::enable();
+
 	println!("Hello World!");
+
+	#[cfg(feature = "instrument")]
+	rftrace_frontend::dump_full_uftrace(events, "trace", "hello_world", true)
+		.expect("Saving trace failed");
 }

--- a/examples/httpd/Cargo.toml
+++ b/examples/httpd/Cargo.toml
@@ -23,7 +23,6 @@ acpi = ["hermit-sys/acpi"]
 fsgsbase = ["hermit-sys/fsgsbase"]
 smp = ["hermit-sys/smp"]
 smoltcp = ["hermit-sys/smoltcp"]
-instrument = ["hermit-sys/instrument"]
 
 [profile.release]
 opt-level = 3

--- a/examples/httpd/Cargo.toml
+++ b/examples/httpd/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["named-profiles"]
 [package]
 name = "httpd"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
@@ -28,8 +29,12 @@ smoltcp = ["hermit-sys/smoltcp"]
 opt-level = 3
 debug = false
 rpath = false
-lto = true
+lto = false
 debug-assertions = false
+
+[profile.release-lto]
+inherits = "release"
+lto = "thin"
 
 [profile.dev]
 opt-level = 1      # controls the `--opt-level` the compiler builds with

--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hermit-abi"
 version = "0.1.18"
 authors = ["Stefan Lankes"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2018"
 description = """

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -57,4 +57,3 @@ features = ["std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-
 version = "0.1.0"
 optional = true
 features = ["autokernel", "buildcore", "interruptsafe"]
-

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hermit-sys"
 version = "0.1.20"
 authors = ["Stefan Lankes"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "FFI bindings to HermitCore"
 repository = "https://github.com/hermitcore/rusty-hermit"
 readme = "README.md"

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -88,6 +88,9 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 	#[cfg(feature = "instrument")]
 	{
 		cmd.env("RUSTFLAGS", "-Z instrument-mcount");
+	}
+	#[cfg(not(feature = "instrument"))]
+	{
 		// if instrument is not set, ensure that instrument is not in environment variables!
 		cmd.env(
 			"RUSTFLAGS",

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -43,7 +43,7 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 		None => src_dir.join("target"),
 	};
 
-	if profile == "release" {
+	if profile == "release" || profile == "release-lto" {
 		cmd.arg("--release");
 	}
 

--- a/hermit-sys/src/lib.rs
+++ b/hermit-sys/src/lib.rs
@@ -2,6 +2,8 @@
 extern crate aarch64;
 #[macro_use]
 extern crate log;
+#[cfg(feature = "instrument")]
+extern crate rftrace;
 #[cfg(feature = "smoltcp")]
 extern crate smoltcp;
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
Add an example to show, how we are able to trace RustyHermit applications. For instance, the following command builds the demo application with tracing support:

> RUSTFLAGS="-Z instrument-mcount" cargo build -p rusty_demo --release --features=instrument

Afterwards, we have to create an output directory `trace` in the current working directory and run the application within `uhyve`.

> mkdir trace
> uhyve -m 512M target/x86_64-unknown-hermit/debug/pi_sequential

The outputs in the trace folder is compatible to the [uftrace's Data Format](https://github.com/namhyung/uftrace/wiki/Data-Format). However, the file with the symbol names and their addresses are missing. In the current stage, we have to create this file by hand. `nm` can be used to create a file with all symbol addresses.

> nm -n target/x86_64-unknown-hermit/release/pi_sequential > trace/pi_sequential-nm.sym

Our binary, is relocatable and starts at address `0x0`. But the loader move the binary to a valid start address. Consequently, we have to add to all symbol addresses the start address of the kernel. `awk` helps us to modify the start addresses:

> awk '{$0="0x"$0;  printf "%x", $0+4194304; print substr($0, index($0, " "))}' trace/pi_sequential-nm.sym > trace/pi_sequential.sym 

In this case, the kernel messages show that the start address is  located at `0x400000` (= `4194304`) and the script adds the start address to all symbol addresses.

To visualize the results, we are able to use [Perfetto](https://perfetto.dev/). In this case, we have to convert the trace files to the Chrome trace viewer format as follows:

> uftrace dump --chrome > trace.json

Afterwards the json file can be be uploaded to Perfetto and anaylzed.