### PR TITLE
feat: add 64-bit RISC-V support

### DIFF
--- a/benches/micro/Cargo.toml
+++ b/benches/micro/Cargo.toml
@@ -15,6 +15,9 @@ default-features = false
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64 = { version = "0.0.10", default-features = false }
 
+[target.'cfg(target_arch = "riscv64")'.dependencies]
+riscv = "0.10"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 syscalls = { version = "0.6", default-features = false }
 

--- a/benches/micro/src/benches/mod.rs
+++ b/benches/micro/src/benches/mod.rs
@@ -37,6 +37,12 @@ fn get_timestamp() -> u64 {
 	CNTPCT_EL0.get()
 }
 
+#[cfg(target_arch = "riscv64")]
+#[inline]
+fn get_timestamp() -> u64 {
+	riscv::register::time::read64()
+}
+
 extern "C" {
 	#[cfg(target_os = "hermit")]
 	fn sys_getpid() -> u32;


### PR DESCRIPTION
This is a rebase and squash of https://github.com/simonschoening/rusty-hermit/commit/4768570dd0087a0e2e41a78be96a53a6fe966579.

This is using the `riscv64gc-unknown-hermit` target from [hermitcore/rust/riscv64gc-unknown-hermit](https://github.com/hermitcore/rust/tree/riscv64gc-unknown-hermit).

CC: @simonschoening