### PR TITLE
Extend the FUSE support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "benches/micro",
     "benches/netbench",
     "examples/demo",
+    "examples/fuse_test",
     "examples/hello_world",
     "examples/httpd",
     "examples/testtcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [workspace]
 resolver = "2"
 members = [
-    "hermit-abi",
-    "hermit",
     "benches/alloc",
-    "benches/netbench",
     "benches/micro",
-    "examples/tokio",
+    "benches/netbench",
+    "examples/demo",
     "examples/hello_world",
     "examples/httpd",
-    "examples/demo",
     "examples/testtcp",
     "examples/testudp",
+    "examples/tokio",
+    "hermit",
+    "hermit-abi",
 ]
 exclude = ["target", "kernel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "examples/testtcp",
     "examples/testudp",
     "examples/tokio",
+    "examples/webserver",
     "hermit",
     "hermit-abi",
 ]

--- a/examples/fuse_test/Cargo.toml
+++ b/examples/fuse_test/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fuse_test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[target.'cfg(target_os = "hermit")'.dependencies.hermit]
+path = "../../hermit"
+default-features = false
+
+[features]
+default = ["pci", "acpi", "fs"]
+vga = ["hermit/vga"]
+fs = ["hermit/fs"]
+pci = ["hermit/pci"]
+pci-ids = ["hermit/pci-ids"]
+acpi = ["hermit/acpi"]
+fsgsbase = ["hermit/fsgsbase"]
+smp = ["hermit/smp"]
+instrument = ["hermit/instrument"]

--- a/examples/fuse_test/src/main.rs
+++ b/examples/fuse_test/src/main.rs
@@ -1,0 +1,59 @@
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+use std::{fs, path::Path};
+
+#[cfg(target_os = "hermit")]
+const TEST_DIR: &str = "/root";
+#[cfg(not(target_os = "hermit"))]
+const TEST_DIR: &str = "/tmp/data";
+
+fn main() {
+	let test_path = Path::new(TEST_DIR);
+	assert!(test_path.is_dir());
+	let paths = fs::read_dir(test_path).unwrap();
+
+	let path_to_new_dir = test_path.join("new_dir");
+
+	assert!(!path_to_new_dir.exists());
+	fs::create_dir(&path_to_new_dir).unwrap();
+	assert!(path_to_new_dir.exists());
+
+	for direntry in paths {
+		let direntry = direntry.unwrap();
+		println!("\nPath: {}", direntry.path().display());
+		println!("Name: {}", direntry.file_name().into_string().unwrap());
+		let file_type = direntry.file_type().unwrap();
+		if file_type.is_dir() {
+			println!("Is dir!");
+		} else if file_type.is_file() {
+			println!("Is file!");
+			println!("Content: {}", fs::read_to_string(direntry.path()).unwrap());
+			let file = fs::File::open(direntry.path()).unwrap();
+			assert!(file.metadata().unwrap().is_file());
+		} else if file_type.is_symlink() {
+			println!("Is symlink!");
+			println!(
+				"Points to file: {:?}",
+				fs::metadata(direntry.path()).unwrap().file_type().is_file()
+			);
+		} else {
+			println!("Unknown type!");
+		}
+
+		let meta_data = direntry.metadata().unwrap();
+		assert!(meta_data.file_type() == file_type);
+
+		println!("Size: {} bytes", meta_data.len());
+		println!("Accessed: {:?}", meta_data.accessed().unwrap());
+		println!("Created: {:?}", meta_data.created().unwrap());
+		println!("Modified: {:?}", meta_data.modified().unwrap());
+		println!("Read only: {:?}", meta_data.permissions().readonly());
+	}
+
+	assert!(path_to_new_dir.exists());
+	fs::remove_dir(&path_to_new_dir).unwrap();
+	assert!(!path_to_new_dir.exists());
+
+	println!("Done.");
+}

--- a/examples/webserver/Cargo.toml
+++ b/examples/webserver/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "webserver"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ascii = "1"
+time = "0.3"
+tiny_http = "0.12"
+
+[target.'cfg(target_os = "hermit")'.dependencies.hermit]
+path = "../../hermit"
+default-features = false
+
+[features]
+default = ["pci", "pci-ids", "fs", "acpi", "tcp"]
+fs = ["hermit/fs"]
+vga = ["hermit/vga"]
+dhcpv4 = ["hermit/dhcpv4"]
+pci = ["hermit/pci"]
+pci-ids = ["hermit/pci-ids"]
+acpi = ["hermit/acpi"]
+fsgsbase = ["hermit/fsgsbase"]
+smp = ["hermit/smp"]
+tcp = ["hermit/tcp"]
+instrument = ["hermit/instrument"]
+trace = ["hermit/trace"]

--- a/examples/webserver/src/main.rs
+++ b/examples/webserver/src/main.rs
@@ -1,0 +1,75 @@
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+use ascii::AsciiString;
+use std::fs;
+use std::path::Path;
+
+extern crate ascii;
+extern crate tiny_http;
+
+#[cfg(target_os = "hermit")]
+const ROOT_DIR: &str = "/root";
+#[cfg(not(target_os = "hermit"))]
+const ROOT_DIR: &str = "/tmp/data";
+
+fn get_content_type(path: &Path) -> &'static str {
+	let extension = match path.extension() {
+		None => return "text/plain",
+		Some(e) => e,
+	};
+
+	match extension.to_str().unwrap() {
+		"gif" => "image/gif",
+		"jpg" => "image/jpeg",
+		"jpeg" => "image/jpeg",
+		"png" => "image/png",
+		"pdf" => "application/pdf",
+		"htm" => "text/html; charset=utf8",
+		"html" => "text/html; charset=utf8",
+		"txt" => "text/plain; charset=utf8",
+		"css" => "text/css; charset=utf8",
+		_ => "text/plain; charset=utf8",
+	}
+}
+
+fn main() {
+	let root_path = Path::new(ROOT_DIR);
+	assert!(root_path.is_dir());
+
+	#[cfg(not(target_os = "hermit"))]
+	let server = tiny_http::Server::http("0.0.0.0:9000").unwrap();
+
+	#[cfg(target_os = "hermit")]
+	let server = tiny_http::Server::http("0.0.0.0:8000").unwrap();
+
+	let port = server.server_addr().to_ip().unwrap().port();
+	println!("Now listening on port {}", port);
+
+	loop {
+		let rq = match server.recv() {
+			Ok(rq) => rq,
+			Err(_) => break,
+		};
+
+		println!("{:?}", rq);
+
+		let url = rq.url().to_string();
+		let path = root_path.join(Path::new(&url[1..]));
+		println!("Path: {}", path.display());
+
+		if let Ok(file) = fs::File::open(&path) {
+			let response = tiny_http::Response::from_file(file);
+
+			let response = response.with_header(tiny_http::Header {
+				field: "Content-Type".parse().unwrap(),
+				value: AsciiString::from_ascii(get_content_type(&path)).unwrap(),
+			});
+
+			let _ = rq.respond(response);
+		} else {
+			let rep = tiny_http::Response::new_empty(tiny_http::StatusCode(404));
+			let _ = rq.respond(rep);
+		}
+	}
+}

--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Stefan Lankes"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Add new system calls to the ABI (mkdir, rmdir, lstat, fstat, opendir, readdir) to extend the filesystem support. The stat system call was already present in libhermit-rs. We changed its declaration and also added it to the ABI.

The two examples (fuse_test, webserver) were used for testing our changes and do not have to be merged.

Rebase and replace #445 