### PR TITLE
chore: remove .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.gif filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
The last LFS files were removed in https://github.com/hermit-os/hermit-rs/pull/463.