### PR TITLE
fix(README): remove publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,3 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 Hermit is being developed on [GitHub](https://github.com/hermitcore/hermit-rs).
 Create your own fork, send us a pull request, and chat with us on [Zulip](https://hermit.zulipchat.com/).
-
-## Publications
-
-The following scientific publications are related to Hermit:
-
-- S. Lankes et al. - [Exploring Rust for Unikernel Development](https://dl.acm.org/doi/10.1145/3365137.3365395)
-- M. Sung et al. - [Intra-unikernel isolation with Intel memory protection keys](https://dl.acm.org/doi/10.1145/3381052.3381326)
-- S. Lankes et al. - [RustyHermit: A Scalable, Rust-Based Virtual Execution Environment](https://link.springer.com/chapter/10.1007/978-3-030-59851-8_22)


### PR DESCRIPTION
This is now tracked at org level: https://github.com/hermit-os#publications