### PR TITLE
build.rs: check that cargo binary exists, use exported one otherwise

### DIFF
--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -168,7 +168,11 @@ fn cargo() -> Command {
 		// To reach the rustup proxy nonetheless, we explicitly query $CARGO_HOME.
 		let mut cargo_home = PathBuf::from(env::var_os("CARGO_HOME").unwrap());
 		cargo_home.push("bin/cargo");
-		cargo_home
+		if cargo_home.exists() {
+			cargo_home
+		} else {
+			PathBuf::from("cargo")
+		}
 	};
 
 	let mut cargo = Command::new(cargo);


### PR DESCRIPTION
Hi, I'm building this crate in a CI context where the cargo binary itself is not present under `CARGO_HOME`. Would it be possible to add this check where if cargo cannot be found at the defined path, it is used as exported in the environment. Thanks!