### PR TITLE
add example to test the system calls `recv_from` and `sendto`

### DIFF
--- a/examples/testudp/src/main.rs
+++ b/examples/testudp/src/main.rs
@@ -15,11 +15,20 @@ fn main() {
 	loop {
 		// Receives a single datagram message on the socket.
 		// If `buf` is too small to hold, the message, it will be cut off.
-		println!("about to recv");
-		match socket.recv(&mut buf) {
-			Ok(received) => {
+		match socket.recv_from(&mut buf) {
+			Ok((received, addr)) => {
 				let msg = std::str::from_utf8(&buf[..received]).unwrap();
-				print!("received {}", msg);
+
+				// print msg without suffix `\n`
+				match msg.strip_suffix("\n") {
+					Some(striped_msg) => {
+						println!("received {} from {}", striped_msg, addr);
+					}
+					_ => {
+						println!("received {} from {}", msg, addr);
+					}
+				}
+
 				if msg.starts_with("exit") {
 					break;
 				}

--- a/examples/testudp/src/main.rs
+++ b/examples/testudp/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 				let msg = std::str::from_utf8(&buf[..received]).unwrap();
 
 				// print msg without suffix `\n`
-				match msg.strip_suffix("\n") {
+				match msg.strip_suffix('\n') {
 					Some(striped_msg) => {
 						println!("received {} from {}", striped_msg, addr);
 					}

--- a/examples/testudp/src/main.rs
+++ b/examples/testudp/src/main.rs
@@ -29,6 +29,11 @@ fn main() {
 					}
 				}
 
+				// send message back
+				socket
+					.send_to(msg.as_bytes(), addr)
+					.expect("Unable to send message back");
+
 				if msg.starts_with("exit") {
 					break;
 				}

--- a/examples/testudp/src/main.rs
+++ b/examples/testudp/src/main.rs
@@ -22,10 +22,10 @@ fn main() {
 				// print msg without suffix `\n`
 				match msg.strip_suffix('\n') {
 					Some(striped_msg) => {
-						println!("received {} from {}", striped_msg, addr);
+						println!("received \"{}\" from {}", striped_msg, addr);
 					}
 					_ => {
-						println!("received {} from {}", msg, addr);
+						println!("received \"{}\" from {}", msg, addr);
 					}
 				}
 


### PR DESCRIPTION
This PR is required to test the kernel interface and to solve issue hermit-os/kernel#967 and depends on hermit-os/kernel#1007

