### PR TITLE
fix links to the hermit-rs repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: hermitcore
+        username: hermit-os
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build demo
       run: cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit --no-default-features -p rusty_demo --release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img width="256" align="right" src="https://github.com/hermitcore/.github/blob/main/logo/hermit-logo.svg" />
+<img width="256" align="right" src="https://github.com/hermi-os/.github/blob/main/logo/hermit-logo.svg" />
 
 # Hermit for Rust
 
@@ -10,7 +10,7 @@ A Rust-based, lightweight unikernel.
 Unikernel means, you bundle your application directly with the kernel library, so that it can run without any installed operating system.
 This reduces overhead, therefore, interesting applications include virtual machines and high-performance computing.
 
-The kernel is able to run [Rust](https://github.com/hermitcore/hermit-rs) applications, as well as [C/C++/Go/Fortran](https://github.com/hermitcore/hermit-playground) applications.
+The kernel is able to run [Rust](https://github.com/hermi-os/hermit-rs) applications, as well as [C/C++/Go/Fortran](https://github.com/hermi-os/hermit-playground) applications.
 
 The repository contains following directories and submodules:
 
@@ -23,7 +23,7 @@ The repository contains following directories and submodules:
 ## Background
 
 **Hermit** is a rewrite of HermitCore in [Rust](https://www.rust-lang.org) developed at [RWTH-Aachen](https://www.rwth-aachen.de).
-HermitCore was a research unikernel written in C ([libhermit](https://github.com/hermitcore/libhermit)).
+HermitCore was a research unikernel written in C ([libhermit](https://github.com/hermi-os/libhermit)).
 
 The ownership  model of Rust guarantees memory/thread-safety and enables us to eliminate many classes of bugs at compile-time.
 Consequently, the use of Rust for kernel development promises fewer vulnerabilities in comparison to common programming languages.
@@ -38,16 +38,16 @@ Rust applications that use the Rust runtime and do not directly use OS services 
 
 ## Building your own applications
 
-Have a look at [rusty-demo](https://github.com/hermitcore/rusty-demo).
+Have a look at [rusty-demo](https://github.com/hermi-os/rusty-demo).
 
 
 ## Use Hermit for C/C++, Go, and Fortran applications
 
-If you are interested to build C/C++, Go, and Fortran applications on top of a Rust-based library operating system, please take a look at [https://github.com/hermitcore/hermit-playground](https://github.com/hermitcore/hermit-playground).
+If you are interested to build C/C++, Go, and Fortran applications on top of a Rust-based library operating system, please take a look at [https://github.com/hermi-os/hermit-playground](https://github.com/hermi-os/hermit-playground).
 
 ## Wiki
 
-Please use the [Wiki](https://github.com/hermitcore/hermit-rs/wiki) to get further information and configuration options.
+Please use the [Wiki](https://github.com/hermi-os/hermit-rs/wiki) to get further information and configuration options.
 
 ## Credits
 
@@ -74,5 +74,5 @@ at your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
 
-Hermit is being developed on [GitHub](https://github.com/hermitcore/hermit-rs).
+Hermit is being developed on [GitHub](https://github.com/hermi-os/hermit-rs).
 Create your own fork, send us a pull request, and chat with us on [Zulip](https://hermit.zulipchat.com/).

--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Stefan Lankes"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Hermit system calls definitions."
-repository = "https://github.com/hermitcore/hermit-rs"
+repository = "https://github.com/hermit-os/hermit-rs"
 keywords = ["unikernel", "libos"]
 categories = ["os"]
 

--- a/hermit-abi/README.md
+++ b/hermit-abi/README.md
@@ -1,7 +1,7 @@
 # hermit-abi
 
 [![Crates.io](https://img.shields.io/crates/v/hermit-abi.svg)](https://crates.io/crates/hermit-abi)
-[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://hermit-os.github.io/hermit-rs/hermit_abi/)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.rs/hermit-abi/latest/hermit_abi/)
 [![License](https://img.shields.io/crates/l/hermit-abi.svg)](https://img.shields.io/crates/l/hermit-abi.svg)
 
 This is small interface to call functions from the [Hermit kernel](https://github.com/hermit-os/kernel).

--- a/hermit-abi/README.md
+++ b/hermit-abi/README.md
@@ -1,12 +1,12 @@
 # hermit-abi
 
 [![Crates.io](https://img.shields.io/crates/v/hermit-abi.svg)](https://crates.io/crates/hermit-abi)
-[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://hermitcore.github.io/hermit-rs/hermit_abi/)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://hermit-os.github.io/hermit-rs/hermit_abi/)
 [![License](https://img.shields.io/crates/l/hermit-abi.svg)](https://img.shields.io/crates/l/hermit-abi.svg)
 
-This is small interface to call functions from the [Hermit kernel](https://github.com/hermitcore/kernel).
+This is small interface to call functions from the [Hermit kernel](https://github.com/hermit-os/kernel).
 
-Please read the README of the [Hermit kernel](https://github.com/hermitcore/kernel) for more information.
+Please read the README of the [Hermit kernel](https://github.com/hermit-os/kernel) for more information.
 
 ## License
 

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -1,5 +1,5 @@
 //! `hermit-abi` is small interface to call functions from the
-//! [Hermit unikernel](https://github.com/hermitcore/kernel).
+//! [Hermit unikernel](https://github.com/hermit-os/kernel).
 
 #![no_std]
 #![allow(nonstandard_style)]

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 description = "The Hermit unikernel for Rust."
-repository = "https://github.com/hermitcore/hermit-rs"
+repository = "https://github.com/hermit-os/hermit-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["unikernel", "libos"]
 categories = ["os"]

--- a/hermit/README.md
+++ b/hermit/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/hermit.svg)](https://crates.io/crates/hermit)
 [![docs.rs](https://img.shields.io/docsrs/hermit)](https://docs.rs/hermit)
 
-This crate builds and links against the [Hermit kernel](https://github.com/hermitcore/kernel) to create a Hermit unikernel image.
+This crate builds and links against the [Hermit kernel](https://github.com/hermit-os/kernel) to create a Hermit unikernel image.
 
 ## Building
 
@@ -29,7 +29,7 @@ This crate builds and links against the [Hermit kernel](https://github.com/hermi
 
     -   install [rust-std-hermit] on stable Rust
 
-        [rust-std-hermit]: https://github.com/hermitcore/rust-std-hermit
+        [rust-std-hermit]: https://github.com/hermit-os/rust-std-hermit
 
     or
 
@@ -39,8 +39,8 @@ This crate builds and links against the [Hermit kernel](https://github.com/hermi
 
 You can boot the resulting image in the specialized [Uhyve] unikernel hypervisor or on other platforms like QEMU using the [Hermit loader].
 
-[Uhyve]: https://github.com/hermitcore/uhyve
-[Hermit loader]: https://github.com/hermitcore/loader
+[Uhyve]: https://github.com/hermit-os/uhyve
+[Hermit loader]: https://github.com/hermit-os/loader
 
 ## License
 

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -39,7 +39,7 @@ impl KernelSrc {
 
 		if !src_dir.exists() {
 			let url =
-				format!("https://github.com/hermitcore/kernel/archive/refs/tags/v{version}.tar.gz");
+				format!("https://github.com/hermit-os/kernel/archive/refs/tags/v{version}.tar.gz");
 			let response = ureq::get(url.as_str()).call().unwrap().into_reader();
 			let tar = GzDecoder::new(response);
 			let mut archive = Archive::new(tar);


### PR DESCRIPTION
Old links are still available, but we should the officail links to the GitHub repository.