### PR TITLE
add option to start a simple shell as async task

### DIFF
--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -27,7 +27,7 @@ path = "../../hermit"
 default-features = false
 
 [features]
-default = ["fsgsbase", "dhcpv4", "pci", "pci-ids", "acpi", "tcp"]
+default = ["fsgsbase", "dhcpv4", "pci", "pci-ids", "acpi", "tcp", "shell"]
 vga = ["hermit/vga"]
 dhcpv4 = ["hermit/dhcpv4"]
 pci = ["hermit/pci"]
@@ -40,3 +40,4 @@ instrument = ["hermit/instrument"]
 trace = ["hermit/trace"]
 rtl8139 = ["hermit/rtl8139"]
 ci = []
+shell = ["hermit/shell"]

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -48,6 +48,7 @@ tcp = []
 udp = []
 trace = []
 vga = []
+shell = []
 
 [build-dependencies]
 flate2 = "1"

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -96,7 +96,7 @@ impl KernelSrc {
 			&mut cargo,
 			[
 				"acpi", "dhcpv4", "fsgsbase", "pci", "pci-ids", "smp", "tcp", "udp", "trace",
-				"vga", "rtl8139", "fs",
+				"vga", "rtl8139", "fs", "shell",
 			]
 			.into_iter(),
 		);


### PR DESCRIPTION
Currently, the shell is only able to print the number of received tasks. Type `h` to show the supported commands.

This PR depends on hermit-os/kernel#1096