### PR TITLE
feat: stabilize kernel interface

### DIFF
--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["Stefan Lankes"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
In case, that POSIX provides similiar system calls, HermitOS uses variants of these system calls. These similiarties should increase the readability of the interface.

See also hermit-os/kernel#1167