### PR TITLE
add feature to support DNS requests

### DIFF
--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -153,13 +153,13 @@ pub type pid_t = i32;
 pub type clockid_t = i32;
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct in_addr {
 	pub s_addr: in_addr_t,
 }
 
 #[repr(C, align(4))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct in6_addr {
 	pub s6_addr: [u8; 16],
 }
@@ -576,6 +576,9 @@ extern "C" {
 	/// Wakeup task with the thread id `tid`
 	#[link_name = "sys_wakeup_taskt"]
 	pub fn wakeup_task(tid: Tid);
+
+	#[link_name = "sys_getaddrbyname"]
+	pub fn getaddrbyname(name: *const c_char, inaddr: *mut u8, len: usize) -> i32;
 
 	#[link_name = "sys_accept"]
 	pub fn accept(s: i32, addr: *mut sockaddr, addrlen: *mut socklen_t) -> i32;

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -577,6 +577,28 @@ extern "C" {
 	#[link_name = "sys_wakeup_taskt"]
 	pub fn wakeup_task(tid: Tid);
 
+	/// The system call `getaddrbyname` determine the network host entry.
+	/// It expects an array of u8 with a size of in_addr or of in6_addr.
+	/// The result of the DNS request will be stored in this array.
+	///
+	/// # Example
+	///
+	/// ```
+	/// use hermit_abi::in_addr;
+	/// let c_string = std::ffi::CString::new("rust-lang.org").expect("CString::new failed");
+	/// let name = c_string.into_raw();
+	/// let mut inaddr: in_addr = Default::default();
+	/// let _ = unsafe {
+	///         hermit_abi::getaddrbyname(
+	///                 name,
+	///                 &mut inaddr as *mut _ as *mut u8,
+	///                 std::mem::size_of::<in_addr>(),
+	///         )
+	/// };
+	///
+	/// // retake pointer to free memory
+	/// let _ = CString::from_raw(name);
+	/// ```
 	#[link_name = "sys_getaddrbyname"]
 	pub fn getaddrbyname(name: *const c_char, inaddr: *mut u8, len: usize) -> i32;
 

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -24,6 +24,7 @@ default = [
     "smp",
     "tcp",
     "udp",
+    "dns",
 ]
 
 acpi = []
@@ -46,6 +47,7 @@ rtl8139 = ["pci"]
 smp = []
 tcp = []
 udp = []
+dns = []
 trace = []
 vga = []
 shell = []

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -95,7 +95,7 @@ impl KernelSrc {
 			&mut cargo,
 			[
 				"acpi", "dhcpv4", "fsgsbase", "pci", "pci-ids", "smp", "tcp", "udp", "trace",
-				"vga", "rtl8139", "fs", "shell",
+				"vga", "rtl8139", "fs", "shell", "dns",
 			]
 			.into_iter(),
 		);


### PR DESCRIPTION
The system call `getaddrbyname` is introduced and expects an array of u8 with the size of in_addr or in6_addr. The result of the DNS request is stored in the array.

Example:

```
use hermit_abi::in_addr;
let c_string = std::ffi::CString::new("rust-lang.org").expect("CString::new failed");
let name = c_string.into_raw();
let mut inaddr: in_addr = Default::default();
let _ = unsafe {
	hermit_abi::getaddrbyname(
		name,
		&mut inaddr as *mut _ as *mut u8,
		std::mem::size_of::<in_addr>(),
	)
};

// retake pointer to free memory
let _ = CString::from_raw(name);
```

This PR depends on hermit-os/kernel#1211