### PR TITLE
add system calls `readv` and `writev`

### DIFF
--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -140,7 +140,7 @@ pub const POLLRDHUP: i16 = 0x2000;
 pub const EFD_SEMAPHORE: i16 = 0o1;
 pub const EFD_NONBLOCK: i16 = 0o4000;
 pub const EFD_CLOEXEC: i16 = 0o40000;
-pub const IOV_MAX: i32 = 1024;
+pub const IOV_MAX: usize = 1024;
 pub type sa_family_t = u8;
 pub type socklen_t = u32;
 pub type in_addr_t = u32;
@@ -622,7 +622,7 @@ extern "C" {
 	/// which data should be written.  `readv()` will always fill an completely
 	/// before proceeding to the next.
 	#[link_name = "sys_readv"]
-	pub fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> isize;
+	pub fn readv(fd: i32, iov: *const iovec, iovcnt: usize) -> isize;
 
 	/// `getdents64` reads directory entries from the directory referenced
 	/// by the file descriptor `fd` into the buffer pointed to by `buf`.
@@ -681,7 +681,7 @@ extern "C" {
 	/// which data should be written.  `writev()` will always write a
 	/// complete area before proceeding to the next.
 	#[link_name = "sys_writev"]
-	pub fn writev(fd: i32, iov: *const iovec, iovcnt: i32) -> isize;
+	pub fn writev(fd: i32, iov: *const iovec, iovcnt: usize) -> isize;
 
 	/// close a file descriptor
 	///

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -140,6 +140,7 @@ pub const POLLRDHUP: i16 = 0x2000;
 pub const EFD_SEMAPHORE: i16 = 0o1;
 pub const EFD_NONBLOCK: i16 = 0o4000;
 pub const EFD_CLOEXEC: i16 = 0o40000;
+pub const IOV_MAX: usize = 1024;
 pub type sa_family_t = u8;
 pub type socklen_t = u32;
 pub type in_addr_t = u32;
@@ -289,6 +290,15 @@ pub struct dirent64 {
 	pub d_type: u8,
 	/// Filename (null-terminated)
 	pub d_name: [c_char; 256],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct iovec {
+	/// Starting address
+	pub iov_base: *mut c_void,
+	/// Size of the memory pointed to by iov_base.
+	pub iov_len: usize,
 }
 
 pub const DT_UNKNOWN: u8 = 0;
@@ -595,6 +605,10 @@ extern "C" {
 	#[link_name = "sys_read"]
 	pub fn read(fd: i32, buf: *mut u8, len: usize) -> isize;
 
+	/// read data into multiple buffers
+	#[link_name = "sys_readv"]
+	pub fn readv(fd: i32, iov: *const iovec, iovcnt: usize) -> isize;
+
 	/// `getdents64` reads directory entries from the directory referenced
 	/// by the file descriptor `fd` into the buffer pointed to by `buf`.
 	#[link_name = "sys_getdents64"]
@@ -635,6 +649,10 @@ extern "C" {
 	/// buffer pointed to by `buf`.
 	#[link_name = "sys_write"]
 	pub fn write(fd: i32, buf: *const u8, len: usize) -> isize;
+
+	/// write data from multiple buffers
+	#[link_name = "sys_writev"]
+	pub fn writev(fd: i32, iov: *const iovec, iovcnt: usize) -> isize;
 
 	/// close a file descriptor
 	///

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -294,6 +294,7 @@ pub struct dirent64 {
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
+/// Describes  a  region  of  memory, beginning at `iov_base` address and with the size of `iov_len` bytes.
 pub struct iovec {
 	/// Starting address
 	pub iov_base: *mut c_void,
@@ -605,7 +606,21 @@ extern "C" {
 	#[link_name = "sys_read"]
 	pub fn read(fd: i32, buf: *mut u8, len: usize) -> isize;
 
-	/// read data into multiple buffers
+	/// `read()` attempts to read `nbyte` of data to the object referenced by the
+	/// descriptor `fd` from a buffer. `read()` performs the same
+	/// action, but scatters the input data from the `iovcnt` buffers specified by the
+	/// members of the iov array: `iov[0], iov[1], ..., iov[iovcnt-1]`.
+	///
+	/// ```
+	/// struct iovec {
+	///     char   *iov_base;  /* Base address. */
+	///     size_t iov_len;    /* Length. */
+	/// };
+	/// ```
+	///
+	/// Each `iovec` entry specifies the base address and length of an area in memory from
+	/// which data should be written.  `readv()` will always fill an completely
+	/// before proceeding to the next.
 	#[link_name = "sys_readv"]
 	pub fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> isize;
 
@@ -650,7 +665,21 @@ extern "C" {
 	#[link_name = "sys_write"]
 	pub fn write(fd: i32, buf: *const u8, len: usize) -> isize;
 
-	/// write data from multiple buffers
+	/// `write()` attempts to write `nbyte` of data to the object referenced by the
+	/// descriptor `fd` from a buffer. `writev()` performs the same
+	/// action, but gathers the output data from the `iovcnt` buffers specified by the
+	/// members of the iov array: `iov[0], iov[1], ..., iov[iovcnt-1]`.
+	///
+	/// ```
+	/// struct iovec {
+	///     char   *iov_base;  /* Base address. */
+	///     size_t iov_len;    /* Length. */
+	/// };
+	/// ```
+	///
+	/// Each `iovec` entry specifies the base address and length of an area in memory from
+	/// which data should be written.  `writev()` will always write a
+	/// complete area before proceeding to the next.
 	#[link_name = "sys_writev"]
 	pub fn writev(fd: i32, iov: *const iovec, iovcnt: i32) -> isize;
 

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -140,7 +140,7 @@ pub const POLLRDHUP: i16 = 0x2000;
 pub const EFD_SEMAPHORE: i16 = 0o1;
 pub const EFD_NONBLOCK: i16 = 0o4000;
 pub const EFD_CLOEXEC: i16 = 0o40000;
-pub const IOV_MAX: usize = 1024;
+pub const IOV_MAX: i32 = 1024;
 pub type sa_family_t = u8;
 pub type socklen_t = u32;
 pub type in_addr_t = u32;
@@ -607,7 +607,7 @@ extern "C" {
 
 	/// read data into multiple buffers
 	#[link_name = "sys_readv"]
-	pub fn readv(fd: i32, iov: *const iovec, iovcnt: usize) -> isize;
+	pub fn readv(fd: i32, iov: *const iovec, iovcnt: i32) -> isize;
 
 	/// `getdents64` reads directory entries from the directory referenced
 	/// by the file descriptor `fd` into the buffer pointed to by `buf`.
@@ -652,7 +652,7 @@ extern "C" {
 
 	/// write data from multiple buffers
 	#[link_name = "sys_writev"]
-	pub fn writev(fd: i32, iov: *const iovec, iovcnt: usize) -> isize;
+	pub fn writev(fd: i32, iov: *const iovec, iovcnt: i32) -> isize;
 
 	/// close a file descriptor
 	///


### PR DESCRIPTION
the offers the possibility to read or to write data into multiple buffers.

this PR depends on hermit-os/kernel#1219