### PR TITLE
add option to use a busy waiting within the idle loop

### DIFF
--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -51,6 +51,7 @@ dns = []
 trace = []
 vga = []
 shell = []
+idle-poll = []
 
 [build-dependencies]
 flate2 = "1"

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -94,8 +94,21 @@ impl KernelSrc {
 		forward_features(
 			&mut cargo,
 			[
-				"acpi", "dhcpv4", "fsgsbase", "pci", "pci-ids", "smp", "tcp", "udp", "trace",
-				"vga", "rtl8139", "fs", "shell", "dns",
+				"acpi",
+				"dhcpv4",
+				"fsgsbase",
+				"pci",
+				"pci-ids",
+				"smp",
+				"tcp",
+				"udp",
+				"trace",
+				"vga",
+				"rtl8139",
+				"fs",
+				"shell",
+				"dns",
+				"idle-poll",
 			]
 			.into_iter(),
 		);


### PR DESCRIPTION
Instead of the hlt instruction, the idle loop use the pause instruction.

=> lower latency to wake up the core, but higher energy consumption.

This PR depends on hermit-os/kernel#1243