### PR TITLE
add wasmtime demo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ members = [
     "examples/webserver",
     "examples/dns",
     "examples/mutex",
+    "examples/fibonacci",
+    "examples/wasmtime",
     "hermit",
     "hermit-abi",
 ]

--- a/examples/fibonacci/Cargo.toml
+++ b/examples/fibonacci/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fibonacci"
+version = "0.1.0"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+

--- a/examples/fibonacci/src/lib.rs
+++ b/examples/fibonacci/src/lib.rs
@@ -1,0 +1,37 @@
+// Test library to test the wasmtime demo
+use core::hint::black_box;
+
+extern "C" {
+	fn now() -> f64;
+}
+
+// Just a dummy function to measure the overhead
+#[no_mangle]
+pub extern "C" fn foo() {}
+
+// Calculating fibonacci numbers
+#[no_mangle]
+pub extern "C" fn fibonacci(n: u64) -> u64 {
+	let mut fib: u64 = 1;
+	let mut fib1: u64 = 1;
+	let mut fib2: u64 = 1;
+
+	for _ in 3..=n {
+		fib = fib1 + fib2;
+		fib1 = fib2;
+		fib2 = fib;
+	}
+
+	fib
+}
+
+#[no_mangle]
+pub extern "C" fn bench(iterations: u64, number: u64) -> f64 {
+	let start = unsafe { now() };
+	for _ in 0..iterations {
+		black_box(fibonacci(black_box(number)));
+	}
+	let end = unsafe { now() };
+
+	end - start
+}

--- a/examples/wasmtime/Cargo.toml
+++ b/examples/wasmtime/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "wasmtime-demo"
+version = "0.1.0"
+edition = "2021"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+readme = "README.md"
+license = "MIT/Apache-2.0"
+keywords = ["wasm", "webassembly"]
+
+[dependencies]
+anyhow = "1.0"
+bitflags = "2.5"
+cfg-if = "1"
+log = { version = "0.4" } #, features = ["kv_unstable"]}
+simple_logger = { version = "5.0", default-features = false, features = ["nightly"]}
+wasmtime = { version = "22.0", default-features = false, features = ["std", "runtime", "cranelift", "threads", "gc", "component-model"] }
+
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit = { path = "../../hermit", default-features = false, features = ["smp", "acpi", "pci", "fsgsbase", "fs", "tcp", "dhcpv4", "mmap"] }
+hermit-abi = { path = "../../hermit-abi", default-features = false }

--- a/examples/wasmtime/Makefile
+++ b/examples/wasmtime/Makefile
@@ -1,0 +1,30 @@
+SOURCE_FILES := $(shell test -e src/ && find src -type f)
+
+.PHONY: build
+build: target/x86_64-unknown-hermit/release/wasmi_demo wasm/fib.wasm
+
+target/x86_64-unknown-hermit/release/wasmi_demo: $(SOURCE_FILES) Cargo.* wasm/fib.wasm
+	cargo build \
+		-Zbuild-std=std,panic_abort \
+		--target x86_64-unknown-hermit \
+		--release
+
+wasm/fib.wasm:
+	cd examples; cd fib; cargo build --target wasm32-wasi --release; cp target/wasm32-wasi/release/fib.wasm ../../wasm
+	
+.PHONY: clean
+clean:
+	cargo clean
+	rm -f wasm/fib.wasm
+
+.PHONY: run
+run: target/x86_64-unknown-hermit/release/wasmi_demo
+	qemu-system-x86_64 \
+		-cpu qemu64,apic,fsgsbase,fxsr,rdrand,rdtscp,xsave,xsaveopt \
+		-display none -serial stdio \
+		-smp 4 \
+		-m 1G \
+		-device isa-debug-exit,iobase=0xf4,iosize=0x04 \
+		-kernel hermit-loader-x86_64 \
+		-initrd target/x86_64-unknown-hermit/release/wasmi-demo \
+		-netdev user,id=u1,hostfwd=tcp::3000-:3000 -device virtio-net-pci,netdev=u1,disable-legacy=on,packed=on,mq=on

--- a/examples/wasmtime/build.rs
+++ b/examples/wasmtime/build.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+use std::{env, io};
+
+fn main() -> io::Result<()> {
+	let out_dir = env::var_os("OUT_DIR").unwrap();
+
+	let status = Command::new("cargo")
+		.arg("build")
+		.arg("-Zunstable-options")
+		.arg("-Zbuild-std=std,panic_abort")
+		.arg("--target=wasm32-unknown-unknown")
+		.arg("--package=fibonacci")
+		.arg("--release")
+		.arg("--out-dir")
+		.arg(&out_dir)
+		.status()?;
+	assert!(status.success());
+
+	Ok(())
+}

--- a/examples/wasmtime/src/arch/aarch64/longjmp.s
+++ b/examples/wasmtime/src/arch/aarch64/longjmp.s
@@ -1,0 +1,22 @@
+# The code is derived from the musl implementation
+# of longjmp.
+.section .text
+.global longjmp
+longjmp:
+	# IHI0055B_aapcs64.pdf 5.1.1, 5.1.2 callee saved registers
+	ldp x19, x20, [x0,#0]
+	ldp x21, x22, [x0,#16]
+	ldp x23, x24, [x0,#32]
+	ldp x25, x26, [x0,#48]
+	ldp x27, x28, [x0,#64]
+	ldp x29, x30, [x0,#80]
+	ldr x2, [x0,#104]
+	mov sp, x2
+	ldp d8 , d9, [x0,#112]
+	ldp d10, d11, [x0,#128]
+	ldp d12, d13, [x0,#144]
+	ldp d14, d15, [x0,#160]
+
+	cmp w1, 0
+	csinc w0, w1, wzr, ne
+	br x30

--- a/examples/wasmtime/src/arch/aarch64/mod.rs
+++ b/examples/wasmtime/src/arch/aarch64/mod.rs
@@ -1,0 +1,4 @@
+use core::arch::global_asm;
+
+global_asm!(include_str!("setjmp.s"));
+global_asm!(include_str!("longjmp.s"));

--- a/examples/wasmtime/src/arch/aarch64/setjmp.s
+++ b/examples/wasmtime/src/arch/aarch64/setjmp.s
@@ -1,0 +1,20 @@
+# The code is derived from the musl implementation
+# of setjmp.
+.section .text
+.global setjmp
+setjmp:
+    # IHI0055B_aapcs64.pdf 5.1.1, 5.1.2 callee saved registers
+	stp x19, x20, [x0,#0]
+	stp x21, x22, [x0,#16]
+	stp x23, x24, [x0,#32]
+	stp x25, x26, [x0,#48]
+	stp x27, x28, [x0,#64]
+	stp x29, x30, [x0,#80]
+	mov x2, sp
+	str x2, [x0,#104]
+	stp  d8,  d9, [x0,#112]
+	stp d10, d11, [x0,#128]
+	stp d12, d13, [x0,#144]
+	stp d14, d15, [x0,#160]
+	mov x0, #0
+	ret

--- a/examples/wasmtime/src/arch/mod.rs
+++ b/examples/wasmtime/src/arch/mod.rs
@@ -1,0 +1,9 @@
+cfg_if::cfg_if! {
+	if #[cfg(target_arch = "aarch64")] {
+		pub(crate) mod aarch64;
+	} else if #[cfg(target_arch = "x86_64")] {
+		pub(crate) mod x86_64;
+	} else if #[cfg(target_arch = "riscv64")] {
+		pub(crate) mod riscv64;
+	}
+}

--- a/examples/wasmtime/src/arch/riscv64/longjmp.s
+++ b/examples/wasmtime/src/arch/riscv64/longjmp.s
@@ -1,0 +1,36 @@
+# The code is derived from the musl implementation
+# of longjmp.
+.section .text
+.global longjmp
+longjmp:
+    ld s0,    0(a0)
+	ld s1,    8(a0)
+	ld s2,    16(a0)
+	ld s3,    24(a0)
+	ld s4,    32(a0)
+	ld s5,    40(a0)
+	ld s6,    48(a0)
+	ld s7,    56(a0)
+	ld s8,    64(a0)
+	ld s9,    72(a0)
+	ld s10,   80(a0)
+	ld s11,   88(a0)
+	ld sp,    96(a0)
+	ld ra,    104(a0)
+
+	fld fs0,  112(a0)
+	fld fs1,  120(a0)
+	fld fs2,  128(a0)
+	fld fs3,  136(a0)
+	fld fs4,  144(a0)
+	fld fs5,  152(a0)
+	fld fs6,  160(a0)
+	fld fs7,  168(a0)
+	fld fs8,  176(a0)
+	fld fs9,  184(a0)
+	fld fs10, 192(a0)
+	fld fs11, 200(a0)
+
+	seqz a0, a1
+	add a0, a0, a1
+	ret

--- a/examples/wasmtime/src/arch/riscv64/mod.rs
+++ b/examples/wasmtime/src/arch/riscv64/mod.rs
@@ -1,0 +1,4 @@
+use core::arch::global_asm;
+
+global_asm!(include_str!("setjmp.s"));
+global_asm!(include_str!("longjmp.s"));

--- a/examples/wasmtime/src/arch/riscv64/setjmp.s
+++ b/examples/wasmtime/src/arch/riscv64/setjmp.s
@@ -1,0 +1,35 @@
+# The code is derived from the musl implementation
+# of setjmp.
+.section .text
+.global setjmp
+setjmp:
+	sd s0,    0(a0)
+	sd s1,    8(a0)
+	sd s2,    16(a0)
+	sd s3,    24(a0)
+	sd s4,    32(a0)
+	sd s5,    40(a0)
+	sd s6,    48(a0)
+	sd s7,    56(a0)
+	sd s8,    64(a0)
+	sd s9,    72(a0)
+	sd s10,   80(a0)
+	sd s11,   88(a0)
+	sd sp,    96(a0)
+	sd ra,    104(a0)
+
+	fsd fs0,  112(a0)
+	fsd fs1,  120(a0)
+	fsd fs2,  128(a0)
+	fsd fs3,  136(a0)
+	fsd fs4,  144(a0)
+	fsd fs5,  152(a0)
+	fsd fs6,  160(a0)
+	fsd fs7,  168(a0)
+	fsd fs8,  176(a0)
+	fsd fs9,  184(a0)
+	fsd fs10, 192(a0)
+	fsd fs11, 200(a0)
+
+	li a0, 0
+	ret

--- a/examples/wasmtime/src/arch/x86_64/longjmp.s
+++ b/examples/wasmtime/src/arch/x86_64/longjmp.s
@@ -1,0 +1,19 @@
+# The code is derived from the musl implementation
+# of longjmp.
+#
+# Copyright 2011-2012 Nicholas J. Kain,
+# licensed under standard MIT license
+.section .text
+.global longjmp
+longjmp:
+	xor eax,eax
+	cmp esi, 1              /* CF = val ? 0 : 1 */
+	adc eax, esi            /* eax = val + !val */
+	mov rbx, [rdi]
+	mov rbp, [rdi+8] 
+	mov r12, [rdi+16] 
+	mov r13, [rdi+24] 
+	mov r14, [rdi+32] 
+	mov r15, [rdi+40] 
+	mov rsp, [rdi+48] 
+	jmp [rdi+56]

--- a/examples/wasmtime/src/arch/x86_64/mod.rs
+++ b/examples/wasmtime/src/arch/x86_64/mod.rs
@@ -1,0 +1,4 @@
+use core::arch::global_asm;
+
+global_asm!(include_str!("setjmp.s"));
+global_asm!(include_str!("longjmp.s"));

--- a/examples/wasmtime/src/arch/x86_64/setjmp.s
+++ b/examples/wasmtime/src/arch/x86_64/setjmp.s
@@ -1,0 +1,20 @@
+# The code is derived from the musl implementation
+# of setjmp.
+#
+# Copyright 2011-2012 Nicholas J. Kain,
+# licensed under standard MIT license
+.section .text
+.global setjmp
+setjmp:
+mov [rdi], rbx
+mov [rdi+8], rbp
+mov [rdi+16], r12
+mov [rdi+24], r13
+mov [rdi+32], r14
+mov [rdi+40], r15
+lea rdx, [rsp+8] # rsp without current ret addr
+mov [rdi+48], rdx
+mov rdi, rsp     # save return addr ptr for new rip
+mov [rdi+56], rdx
+xor rax, rax
+ret

--- a/examples/wasmtime/src/capi.rs
+++ b/examples/wasmtime/src/capi.rs
@@ -1,0 +1,282 @@
+use std::cell::UnsafeCell;
+
+use bitflags::bitflags;
+use log::error;
+
+bitflags! {
+	/// Flags to either `wasmtime_mmap_{new,remap}` or `wasmtime_mprotect`.
+	#[repr(transparent)]
+	#[derive(Debug, Copy, Clone, Default)]
+	pub struct WasmProt: u32 {
+		/// Pages may not be accessed.
+		const None = 0;
+		/// Indicates that the memory region should be readable.
+		const Read = 1 << 0;
+		/// Indicates that the memory region should be writable.
+		const Write = 1 << 1;
+		/// Indicates that the memory region should be executable.
+		const Exec = 1 << 2;
+	}
+}
+
+extern "C" {
+	fn setjmp(buf: *const u8) -> i32;
+	fn longjmp(jmp_buf: *const u8, val: i32) -> !;
+}
+
+/// Handler function for traps in Wasmtime passed to `wasmtime_init_traps`.
+///
+/// This function is invoked whenever a trap is caught by the system. For
+/// example this would be invoked during a signal handler on Linux. This
+/// function is passed a number of parameters indicating information about the
+/// trap:
+///
+/// * `ip` - the instruction pointer at the time of the trap.
+/// * `fp` - the frame pointer register's value at the time of the trap.
+/// * `has_faulting_addr` - whether this trap is associated with an access
+///   violation (e.g. a segfault) meaning memory was accessed when it shouldn't
+///   be. If this is `true` then the next parameter is filled in.
+/// * `faulting_addr` - if `has_faulting_addr` is true then this is the address
+///   that was attempted to be accessed. Otherwise this value is not used.
+///
+/// If this function returns then the trap was not handled by Wasmtime. This
+/// means that it's left up to the embedder how to deal with the trap/signal
+/// depending on its default behavior. This could mean forwarding to a
+/// non-Wasmtime handler, aborting the process, logging then crashing, etc. The
+/// meaning of a trap that's not handled by Wasmtime depends on the context in
+/// which the trap was generated.
+///
+/// When this function does not return it's because `wasmtime_longjmp` is
+/// used to handle a Wasm-based trap.
+#[allow(non_camel_case_types)]
+pub type wasmtime_trap_handler_t =
+	extern "C" fn(ip: usize, fp: usize, has_faulting_addr: bool, faulting_addr: usize);
+
+/// Abstract pointer type used in the `wasmtime_memory_image_*` APIs which
+/// is defined by the embedder.
+#[allow(non_camel_case_types)]
+pub enum wasmtime_memory_image {}
+
+#[thread_local]
+static TLS: UnsafeCell<*mut u8> = UnsafeCell::new(core::ptr::null_mut());
+
+/// Wasmtime requires a single pointer's space of TLS to be used at runtime,
+/// and this function returns the current value of the TLS variable.
+///
+/// This value should default to `NULL`.
+#[no_mangle]
+pub extern "C" fn wasmtime_tls_get() -> *mut u8 {
+	unsafe { TLS.get().read() }
+}
+
+// Sets the current TLS value for Wasmtime to the provided value.
+///
+/// This value should be returned when later calling `wasmtime_tls_get`.
+#[no_mangle]
+pub extern "C" fn wasmtime_tls_set(ptr: *mut u8) {
+	unsafe {
+		TLS.get().write(ptr);
+	}
+}
+
+/// Initializes trap-handling logic for this platform.
+///
+/// Wasmtime's implementation of WebAssembly relies on the ability to catch
+/// signals/traps/etc. For example divide-by-zero may raise a machine
+/// exception. Out-of-bounds memory accesses may also raise a machine
+/// exception. This function is used to initialize trap handling.
+///
+/// The `handler` provided is a function pointer to invoke whenever a trap
+/// is encountered. The `handler` is invoked whenever a trap is caught by
+/// the system.
+///
+/// Returns 0 on success and an error code on failure.
+#[no_mangle]
+pub extern "C" fn wasmtime_init_traps(_handler: wasmtime_trap_handler_t) -> i32 {
+	0
+}
+
+/// Used to setup a frame on the stack to longjmp back to in the future.
+///
+/// This function is used for handling traps in WebAssembly and is paried
+/// with `wasmtime_longjmp`.
+///
+/// * `jmp_buf` - this argument is filled in with a pointer which if used
+///   will be passed to `wasmtime_longjmp` later on by the runtime.
+/// * `callback` - this callback should be invoked after `jmp_buf` is
+///   configured.
+/// * `payload` and `callee` - the two arguments to pass to `callback`.
+///
+/// Returns 0 if `wasmtime_longjmp` was used to return to this function.
+/// Returns 1 if `wasmtime_longjmp` was not called and `callback` returned.
+#[no_mangle]
+pub extern "C" fn wasmtime_setjmp(
+	jmp_buf: *mut *const u8,
+	callback: extern "C" fn(*mut u8, *mut u8),
+	payload: *mut u8,
+	callee: *mut u8,
+) -> i32 {
+	cfg_if::cfg_if! {
+		if #[cfg(target_arch = "aarch64")] {
+			const BUF_SIZE: usize = 176;
+		} else if #[cfg(target_arch = "x86_64")] {
+			const BUF_SIZE: usize = 64;
+		} else if #[cfg(target_arch = "riscv64")] {
+			const BUF_SIZE: usize = 208;
+		}
+	}
+
+	let buf: [u8; BUF_SIZE] = [0; BUF_SIZE];
+
+	unsafe {
+		if setjmp(buf.as_ptr()) != 0 {
+			return 0;
+		}
+
+		*jmp_buf = buf.as_ptr();
+	}
+
+	callback(payload, callee);
+
+	1
+}
+
+/// Paired with `wasmtime_setjmp` this is used to jump back to the `setjmp`
+/// point.
+///
+/// The argument here was originally passed to `wasmtime_setjmp` through its
+/// out-param.
+///
+/// This function cannot return.
+///
+/// This function may be invoked from the `wasmtime_trap_handler_t`
+/// configured by `wasmtime_init_traps`.
+#[no_mangle]
+pub extern "C" fn wasmtime_longjmp(jmp_buf: *const u8) -> ! {
+	unsafe {
+		longjmp(jmp_buf, 1);
+	}
+}
+
+/// Remaps the virtual memory starting at `addr` going for `size` bytes to
+/// the protections specified with a new blank mapping.
+///
+/// This will unmap any prior mappings and decommit them. New mappings for
+/// anonymous memory are used to replace these mappings and the new area
+/// should have the protection specified by `prot_flags`.
+///
+/// Returns 0 on success and an error code on failure.
+///
+/// Similar to `mmap(addr, size, prot_flags, MAP_PRIVATE | MAP_FIXED, 0, -1)` on Linux.
+#[no_mangle]
+pub extern "C" fn wasmtime_mmap_remap(_addr: *mut u8, _size: usize, _prot_flags: WasmProt) -> i32 {
+	error!("Currently. HermitOS doesn't support wasmtime_mmap_remap!");
+	-1
+}
+
+/// Attempts to create a new in-memory image of the `ptr`/`len` combo which
+/// can be mapped to virtual addresses in the future.
+///
+/// On success the returned `wasmtime_memory_image` pointer is stored into `ret`.
+/// This value stored can be `NULL` to indicate that an image cannot be
+/// created but no failure occurred. The structure otherwise will later be
+/// deallocated with `wasmtime_memory_image_free` and
+/// `wasmtime_memory_image_map_at` will be used to map the image into new
+/// regions of the address space.
+///
+/// The `ptr` and `len` arguments are only valid for this function call, if
+/// the image needs to refer to them in the future then it must make a copy.
+///
+/// Both `ptr` and `len` are guaranteed to be page-aligned.
+///
+/// Returns 0 on success and an error code on failure. Note that storing
+/// `NULL` into `ret` is not considered a failure, and failure is used to
+/// indicate that something fatal has happened and Wasmtime will propagate
+/// the error upwards.
+#[no_mangle]
+pub extern "C" fn wasmtime_memory_image_new(
+	_ptr: *const u8,
+	_len: usize,
+	_ret: &mut *mut wasmtime_memory_image,
+) -> i32 {
+	error!("Currently. HermitOS doesn't support wasmtime_memory_image_new!");
+	-1
+}
+
+/// Maps the `image` provided to the virtual address at `addr` and `len`.
+///
+/// This semantically should make it such that `addr` and `len` looks the
+/// same as the contents of what the memory image was first created with.
+/// The mappings of `addr` should be private and changes do not reflect back
+/// to `wasmtime_memory_image`.
+///
+/// In effect this is to create a copy-on-write mapping at `addr`/`len`
+/// pointing back to the memory used by the image originally.
+///
+/// Note that the memory region will be unmapped with `wasmtime_munmap` in
+/// the future.
+///
+/// Aborts the process on failure.
+#[no_mangle]
+pub extern "C" fn wasmtime_memory_image_map_at(
+	_image: *mut wasmtime_memory_image,
+	_addr: *mut u8,
+	_len: usize,
+) -> i32 {
+	error!("Currently. HermitOS doesn't support wasmtime_memory_image_map_at!");
+	-1
+}
+
+/// Deallocates the provided `wasmtime_memory_image`.
+///
+/// Note that mappings created from this image are not guaranteed to be
+/// deallocated and/or unmapped before this is called.
+#[no_mangle]
+pub extern "C" fn wasmtime_memory_image_free(_image: *mut wasmtime_memory_image) {
+	error!("Currently. HermitOS doesn't support wasmtime_memory_image_free!");
+}
+
+/// Returns the page size, in bytes, of the current system.
+#[no_mangle]
+pub extern "C" fn wasmtime_page_size() -> usize {
+	unsafe { hermit_abi::getpagesize().try_into().unwrap() }
+}
+
+/// Creates a new virtual memory mapping of the `size` specified with
+/// protection bits specified in `prot_flags`.
+///
+/// Memory can be lazily committed.
+///
+/// Stores the base pointer of the new mapping in `ret` on success.
+///
+/// Returns 0 on success and an error code on failure.
+///
+/// Similar to `mmap(0, size, prot_flags, MAP_PRIVATE, 0, -1)` on Linux.
+#[no_mangle]
+pub extern "C" fn wasmtime_mmap_new(size: usize, prot_flags: u32, ret: &mut *mut u8) -> i32 {
+	unsafe { hermit_abi::mmap(size, prot_flags, ret) }
+}
+
+/// Unmaps memory at the specified `ptr` for `size` bytes.
+///
+/// The memory should be discarded and decommitted and should generate a
+/// segfault if accessed after this function call.
+///
+/// Returns 0 on success and an error code on failure.
+///
+/// Similar to `munmap` on Linux.
+#[no_mangle]
+pub extern "C" fn wasmtime_munmap(ptr: *mut u8, size: usize) -> i32 {
+	unsafe { hermit_abi::munmap(ptr, size) }
+}
+
+/// Configures the protections associated with a region of virtual memory
+/// starting at `ptr` and going to `size`.
+///
+/// Returns 0 on success and an error code on failure.
+///
+/// Similar to `mprotect` on Linux.
+#[no_mangle]
+pub extern "C" fn wasmtime_mprotect(ptr: *mut u8, size: usize, prot_flags: u32) -> i32 {
+	unsafe { hermit_abi::mprotect(ptr, size, prot_flags) }
+}

--- a/examples/wasmtime/src/main.rs
+++ b/examples/wasmtime/src/main.rs
@@ -1,0 +1,131 @@
+#![feature(thread_local)]
+#![feature(duration_millis_float)]
+#![allow(dependency_on_unit_never_type_fallback)]
+
+use std::hint::black_box;
+use std::time::{Instant, SystemTime};
+
+use anyhow::Result;
+#[cfg(target_os = "hermit")]
+use hermit as _;
+use log::{debug, info};
+use wasmtime::*;
+
+#[cfg(target_os = "hermit")]
+mod arch;
+#[cfg(target_os = "hermit")]
+mod capi;
+
+// Number of iteration to stress the benchmark
+const N: u64 = 1000000;
+
+#[inline(never)]
+pub fn native_fibonacci(n: u64) -> u64 {
+	let mut fib: u64 = 1;
+	let mut fib1: u64 = 1;
+	let mut fib2: u64 = 1;
+
+	for _ in 3..=n {
+		fib = fib1 + fib2;
+		fib1 = fib2;
+		fib2 = fib;
+	}
+
+	fib
+}
+
+fn main() -> Result<()> {
+	simple_logger::init_with_level(log::Level::Info).unwrap();
+
+	println!("Start Wasmtime demo!");
+
+	// First step is to create the Wasm execution engine with some config.
+	// In this example we are using the default configuration.
+	let config = wasmtime::Config::new();
+	info!("Wasmtime engine is configured as followed: {:?}", config);
+	let engine = Engine::new(&config)?;
+
+	// TODO: dirty workaround to get the WebAssembly module into
+	// the VM. Find a way to inject the `.wasm` file into the VM
+	// using another way
+	debug!("Create Module");
+	let module_bytes = include_bytes!(concat!(env!("OUT_DIR"), "/fibonacci.wasm"));
+	let now = Instant::now();
+	let module = Module::new(&engine, &module_bytes[..])?;
+	let elapsed = now.elapsed();
+	println!("Time to create mdoule: {} msec", elapsed.as_millis());
+
+	let imports = module.imports();
+	for i in imports {
+		info!("import from module `{}` symbol `{}`", i.module(), i.name());
+	}
+
+	debug!("Create Linker");
+	let mut linker = Linker::new(&engine);
+
+	// In case WASI, it is required to emulate
+	// https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
+
+	linker.func_wrap("env", "now", || {
+		match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+			Ok(n) => n.as_millis_f64(),
+			Err(_) => panic!("SystemTime before UNIX EPOCH!"),
+		}
+	})?;
+	linker.func_wrap("env", "exit", || panic!("Panic in WASM module"))?;
+
+	// All wasm objects operate within the context of a "store". Each
+	// `Store` has a type parameter to store host-specific data, which in
+	// this case we're using `4` for.
+	let mut store = Store::new(&engine, 4);
+	let instance = linker.instantiate(&mut store, &module)?;
+
+	debug!("Try to find function fibonacci");
+	let fibonacci = instance.get_typed_func::<u64, u64>(&mut store, "fibonacci")?;
+
+	// And finally we can call the wasm!
+	debug!("Call function fibonacci");
+	let result = fibonacci.call(&mut store, 30)?;
+	println!("fibonacci(30) = {}", result);
+	assert!(
+		result == 832040,
+		"Error in the calculation of fibonacci(30) "
+	);
+
+	let now = Instant::now();
+	for _ in 0..N {
+		let _result = black_box(fibonacci.call(&mut store, black_box(30)))?;
+	}
+	let elapsed = now.elapsed();
+	println!(
+		"Time to call {} times fibonacci(30): {} usec",
+		N,
+		elapsed.as_micros()
+	);
+
+	let now = Instant::now();
+	for _ in 0..N {
+		let _result = black_box(native_fibonacci(black_box(30)));
+	}
+	let elapsed = now.elapsed();
+	println!(
+		"Time to call {} times native_fibonacci(30): {} usec",
+		N,
+		elapsed.as_micros()
+	);
+
+	let bench = instance.get_typed_func::<(u64, u64), f64>(&mut store, "bench")?;
+	let msec = bench.call(&mut store, (N, 30))?;
+	println!("Benchmark takes {} usec", msec * 1000.0f64);
+
+	let function_foo = instance.get_typed_func::<(), ()>(&mut store, "foo")?;
+	function_foo.call(&mut store, ())?;
+	let now = Instant::now();
+	for _ in 0..N {
+		function_foo.call(&mut store, ())?;
+	}
+	let elapsed = now.elapsed();
+	println!("Time to call {} times foo: {} usec", N, elapsed.as_micros());
+
+	Ok(())
+}

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -328,6 +328,15 @@ pub const S_IFLNK: u32 = 0o12_0000;
 pub const S_IFSOCK: u32 = 0o14_0000;
 pub const S_IFMT: u32 = 0o17_0000;
 
+/// Pages may not be accessed.
+pub const PROT_NONE: u32 = 0;
+/// Indicates that the memory region should be readable.
+pub const PROT_READ: u32 = 1 << 0;
+/// Indicates that the memory region should be writable.
+pub const PROT_WRITE: u32 = 1 << 1;
+/// Indicates that the memory region should be executable.
+pub const PROT_EXEC: u32 = 1 << 2;
+
 // symbols, which are part of the library operating system
 extern "C" {
 	/// Get the last error number from the thread local storage
@@ -337,6 +346,26 @@ extern "C" {
 	/// Get the last error number from the thread local storage
 	#[link_name = "sys_errno"]
 	pub fn errno() -> i32;
+
+	/// Get memory page size
+	#[link_name = "sys_getpagesize"]
+	pub fn getpagesize() -> i32;
+
+	/// Creates a new virtual memory mapping of the `size` specified with
+	/// protection bits specified in `prot_flags`.
+	#[link_name = "sys_mmap"]
+	pub fn mmap(size: usize, prot_flags: u32, ret: &mut *mut u8) -> i32;
+
+	/// Unmaps memory at the specified `ptr` for `size` bytes.
+	#[link_name = "sys_munmap"]
+	pub fn munmap(ptr: *mut u8, size: usize) -> i32;
+
+	/// Configures the protections associated with a region of virtual memory
+	/// starting at `ptr` and going to `size`.
+	///
+	/// Returns 0 on success and an error code on failure.
+	#[link_name = "sys_mprotect"]
+	pub fn mprotect(ptr: *mut u8, size: usize, prot_flags: u32) -> i32;
 
 	/// If the value at address matches the expected value, park the current thread until it is either
 	/// woken up with [`futex_wake`] (returns 0) or an optional timeout elapses (returns -ETIMEDOUT).

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -52,6 +52,7 @@ trace = []
 vga = []
 shell = []
 idle-poll = []
+mmap = []
 
 [build-dependencies]
 flate2 = "1"

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -108,6 +108,7 @@ impl KernelSrc {
 				"fs",
 				"shell",
 				"dns",
+				"mmap",
 				"idle-poll",
 			]
 			.into_iter(),


### PR DESCRIPTION
Wasmtime is a fast and secure runtime for WebAssembly. The demo compiles and run the function `fibonacci`. The source code of the fibonacci function is publish in the directory `examples/fibbonacci`.

The deep `fibonacci` is compiled as followed:

```shell
cargo build -Zbuild-std=std,panic_abort --target wasm32-unknown-unknown -p fibonacci --release
```

This PR depends on hermit-os/kernel#1294 The functions `setjmp` / `longjmp` are derived from the MUSL library, which is ditributed by the MIT license. 