### PR TITLE
add basic support to build applications for a monolithic HermitOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           cargo clippy -Zbuild-std=std,panic_abort --target=x86_64-unknown-hermit --all-targets
           cargo clippy -Zbuild-std=std,panic_abort --target=aarch64-unknown-hermit --all-targets
           cargo clippy -Zbuild-std=std,panic_abort --target=riscv64gc-unknown-hermit --all-targets
+          cargo clippy -Zbuild-std=std,panic_abort --target=x86_64-unknown-hermit --package hermit --features common-os
 
   format:
     name: Format

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -13,6 +13,14 @@ keywords = ["unikernel", "libos"]
 categories = ["os"]
 links = "hermit"
 
+[dependencies]
+hermit-abi = { version = "0.4", optional = true }
+generic_once_cell = { version = "0.1", optional = true }
+libm = { version = "0.2", optional = true }
+spinning_top = { version = "0.3", optional = true }
+take-static = { version = "0.1", optional = true }
+talc = { version = "4.2", default-features = false, features = ["lock_api"], optional = true  }
+
 [features]
 default = [
     "acpi",
@@ -56,6 +64,7 @@ trace = []
 udp = []
 vga = []
 vsock = []
+common-os = ["hermit-abi", "generic_once_cell", "libm", "spinning_top", "take-static", "talc"]
 
 [build-dependencies]
 cc = "1"

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -11,7 +11,8 @@ fn main() {
 	let runs_clippy =
 		env::var_os("CARGO_CFG_FEATURE").is_some_and(|feature| feature == "cargo-clippy");
 	let is_docs_rs = env::var_os("DOCS_RS").is_some();
-	if !targets_hermit || runs_clippy || is_docs_rs {
+	let is_common_os = has_feature("common-os");
+	if !targets_hermit || runs_clippy || is_docs_rs || is_common_os {
 		return;
 	}
 

--- a/hermit/src/lib.rs
+++ b/hermit/src/lib.rs
@@ -1,1 +1,8 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(
+	all(target_os = "hermit", feature = "common-os"),
+	feature(thread_local)
+)]
+
+#[cfg(all(target_os = "hermit", feature = "common-os"))]
+mod syscall;

--- a/hermit/src/syscall/allocator.rs
+++ b/hermit/src/syscall/allocator.rs
@@ -1,0 +1,55 @@
+use core::alloc::Layout;
+use core::ptr::NonNull;
+use std::mem::MaybeUninit;
+
+use generic_once_cell::Lazy;
+use spinning_top::RawSpinlock;
+use talc::{ErrOnOom, Talc, Talck};
+
+static ALLOC: Lazy<RawSpinlock, Talck<RawSpinlock, ErrOnOom>> = Lazy::new(|| {
+	take_static::take_static! {
+		static MEM: [MaybeUninit<u8>; 0x1000] = [MaybeUninit::uninit(); 0x1000];
+	}
+
+	let mem = MEM.take().unwrap();
+
+	let mut talc = Talc::new(talc::ErrOnOom);
+	unsafe {
+		talc.claim(mem.into()).unwrap();
+	}
+
+	Talck::new(talc)
+});
+
+#[no_mangle]
+pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
+	let layout = Layout::from_size_align(size, align).unwrap();
+	unsafe { ALLOC.lock().malloc(layout).unwrap().as_mut() }
+}
+
+#[no_mangle]
+pub extern "C" fn sys_realloc(ptr: *mut u8, size: usize, align: usize, new_size: usize) -> *mut u8 {
+	unsafe {
+		let layout = Layout::from_size_align(size, align).unwrap();
+		if new_size > size {
+			ALLOC
+				.lock()
+				.grow(NonNull::new_unchecked(ptr), layout, new_size)
+				.unwrap()
+				.as_mut()
+		} else {
+			ALLOC
+				.lock()
+				.shrink(NonNull::new_unchecked(ptr), layout, new_size);
+			ptr
+		}
+	}
+}
+
+#[no_mangle]
+pub extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
+	let layout = Layout::from_size_align(size, align).unwrap();
+	unsafe {
+		ALLOC.lock().free(NonNull::new_unchecked(ptr), layout);
+	}
+}

--- a/hermit/src/syscall/math.rs
+++ b/hermit/src/syscall/math.rs
@@ -1,0 +1,165 @@
+//! C-compatible math functions ([`math.h`]).
+//!
+//! [`math.h`]: https://en.cppreference.com/w/c/numeric/math
+
+macro_rules! export {
+    ($(fn $fn:ident($($arg:ident: $argty:ty),+) -> $retty:ty;)+) => {
+        $(
+            #[no_mangle]
+            pub extern "C" fn $fn($($arg: $argty),+) -> $retty {
+                ::libm::$fn($($arg),+)
+            }
+        )+
+    };
+}
+
+export! {
+	fn acos(x: f64) -> f64;
+	fn acosf(x: f32) -> f32;
+	fn acosh(x: f64) -> f64;
+	fn acoshf(x: f32) -> f32;
+	fn asin(x: f64) -> f64;
+	fn asinf(x: f32) -> f32;
+	fn asinh(x: f64) -> f64;
+	fn asinhf(x: f32) -> f32;
+	fn atan(x: f64) -> f64;
+	fn atan2(y: f64, x: f64) -> f64;
+	fn atan2f(y: f32, x: f32) -> f32;
+	fn atanf(x: f32) -> f32;
+	fn atanh(x: f64) -> f64;
+	fn atanhf(x: f32) -> f32;
+	fn cbrt(x: f64) -> f64;
+	fn cbrtf(x: f32) -> f32;
+	fn ceil(x: f64) -> f64;
+	fn ceilf(x: f32) -> f32;
+	fn copysign(x: f64, y: f64) -> f64;
+	fn copysignf(x: f32, y: f32) -> f32;
+	fn cos(x: f64) -> f64;
+	fn cosf(x: f32) -> f32;
+	fn cosh(x: f64) -> f64;
+	fn coshf(x: f32) -> f32;
+	fn erf(x: f64) -> f64;
+	fn erfc(x: f64) -> f64;
+	fn erfcf(x: f32) -> f32;
+	fn erff(x: f32) -> f32;
+	fn exp(x: f64) -> f64;
+	fn exp10(x: f64) -> f64;
+	fn exp10f(x: f32) -> f32;
+	fn exp2(x: f64) -> f64;
+	fn exp2f(x: f32) -> f32;
+	fn expf(x: f32) -> f32;
+	fn expm1(x: f64) -> f64;
+	fn expm1f(x: f32) -> f32;
+	fn fabs(n: f64) -> f64;
+	fn fabsf(n: f32) -> f32;
+	fn fdim(x: f64, y: f64) -> f64;
+	fn fdimf(x: f32, y: f32) -> f32;
+	fn floor(x: f64) -> f64;
+	fn floorf(x: f32) -> f32;
+	fn fma(x: f64, y: f64, z: f64) -> f64;
+	fn fmaf(x: f32, y: f32, z: f32) -> f32;
+	fn fmax(x: f64, y: f64) -> f64;
+	fn fmaxf(x: f32, y: f32) -> f32;
+	fn fmin(x: f64, y: f64) -> f64;
+	fn fminf(x: f32, y: f32) -> f32;
+	fn fmod(x: f64, y: f64) -> f64;
+	fn fmodf(x: f32, y: f32) -> f32;
+	// fn frexp(x: f64, n: &mut i32) -> f64;
+	// fn frexpf(x: f32, n: &mut i32) -> f32;
+	fn hypot(x: f64, y: f64) -> f64;
+	fn hypotf(x: f32, y: f32) -> f32;
+	fn ilogb(x: f64) -> i32;
+	fn ilogbf(x: f32) -> i32;
+	fn j0(x: f64) -> f64;
+	fn j0f(x: f32) -> f32;
+	fn j1(x: f64) -> f64;
+	fn j1f(x: f32) -> f32;
+	fn jn(n: i32, x: f64) -> f64;
+	fn jnf(n: i32, x: f32) -> f32;
+	fn ldexp(x: f64, n: i32) -> f64;
+	fn ldexpf(x: f32, n: i32) -> f32;
+	fn lgamma(x: f64) -> f64;
+	// fn lgamma_r(x: f64, n: &mut i32) -> f64;
+	fn lgammaf(x: f32) -> f32;
+	// fn lgammaf_r(x: f32, n: &mut i32) -> f32;
+	fn log(x: f64) -> f64;
+	fn log10(x: f64) -> f64;
+	fn log10f(x: f32) -> f32;
+	fn log1p(x: f64) -> f64;
+	fn log1pf(x: f32) -> f32;
+	fn log2(x: f64) -> f64;
+	fn log2f(x: f32) -> f32;
+	fn logf(x: f32) -> f32;
+	// fn modf(x: f64, y: &mut f64) -> f64;
+	// fn modff(x: f32, y: &mut f32) -> f32;
+	fn nextafter(x: f64, y: f64) -> f64;
+	fn nextafterf(x: f32, y: f32) -> f32;
+	fn pow(x: f64, y: f64) -> f64;
+	fn powf(x: f32, y: f32) -> f32;
+	fn remainder(x: f64, y: f64) -> f64;
+	fn remainderf(x: f32, y: f32) -> f32;
+	// fn remquo(x: f64, y: f64, n: &mut i32) -> f64;
+	// fn remquof(x: f32, y: f32, n: &mut i32) -> f32;
+	fn rint(x: f64) -> f64;
+	fn rintf(x: f32) -> f32;
+	fn round(x: f64) -> f64;
+	fn roundf(x: f32) -> f32;
+	fn scalbn(x: f64, n: i32) -> f64;
+	fn scalbnf(x: f32, n: i32) -> f32;
+	fn sin(x: f64) -> f64;
+	// fn sincos(x: f64, s: &mut f64, c: &mut f64);
+	// fn sincosf(x: f32, s: &mut f32, c: &mut f32);
+	fn sinf(x: f32) -> f32;
+	fn sinh(x: f64) -> f64;
+	fn sinhf(x: f32) -> f32;
+	fn sqrt(x: f64) -> f64;
+	fn sqrtf(x: f32) -> f32;
+	fn tan(x: f64) -> f64;
+	fn tanf(x: f32) -> f32;
+	fn tanh(x: f64) -> f64;
+	fn tanhf(x: f32) -> f32;
+	fn tgamma(x: f64) -> f64;
+	fn tgammaf(x: f32) -> f32;
+	fn trunc(n: f64) -> f64;
+	fn truncf(n: f32) -> f32;
+	fn y0(x: f64) -> f64;
+	fn y0f(n: f32) -> f32;
+	fn y1(n: f64) -> f64;
+	fn y1f(n: f32) -> f32;
+	fn yn(n: i32, x: f64) -> f64;
+	fn ynf(n: i32, x: f32) -> f32;
+}
+
+macro_rules! export_out_param {
+    ($(fn $fn:ident($($arg:ident: $argty:ty),+; $out:ident: $outty:ty) -> $retty:ty;)+) => {
+        $(
+            #[no_mangle]
+            pub extern "C" fn $fn($($arg: $argty),+, $out: $outty) -> $retty {
+                let (ret, out) = ::libm::$fn($($arg),+);
+                *$out = out;
+                ret
+            }
+        )+
+    };
+}
+
+export_out_param! {
+	fn frexp(x: f64; n: &mut i32) -> f64;
+	fn frexpf(x: f32; n: &mut i32) -> f32;
+	fn lgamma_r(x: f64; n: &mut i32) -> f64;
+	fn lgammaf_r(x: f32; n: &mut i32) -> f32;
+	fn modf(x: f64; y: &mut f64) -> f64;
+	fn modff(x: f32; y: &mut f32) -> f32;
+	fn remquo(x: f64, y: f64; n: &mut i32) -> f64;
+	fn remquof(x: f32, y: f32; n: &mut i32) -> f32;
+}
+
+#[no_mangle]
+pub extern "C" fn sincos(x: f64, s: &mut f64, c: &mut f64) {
+	(*s, *c) = libm::sincos(x);
+}
+
+#[no_mangle]
+pub extern "C" fn sincosf(x: f32, s: &mut f32, c: &mut f32) {
+	(*s, *c) = libm::sincosf(x);
+}

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -1,0 +1,503 @@
+mod math;
+#[cfg(target_arch = "x86_64")]
+#[macro_use]
+pub(crate) mod x86_64;
+mod allocator;
+
+use core::ffi::{c_char, c_void};
+
+use generic_once_cell::Lazy;
+use hermit_abi as abi;
+use spinning_top::RawSpinlock;
+
+use crate::syscall;
+
+pub(crate) enum SyscallNo {
+	/// number of the system call `exit`
+	Exit = 0,
+	/// number of the system call `write`
+	Write = 1,
+	/// number of the system call `read`
+	Read = 2,
+	/// number of the system call `usleep`
+	Usleep = 3,
+	/// number of the system call `getpid`
+	Getpid = 4,
+	/// number of the system call `yield`
+	Yield = 5,
+	/// number of the system call `read_entropy`
+	ReadEntropy = 6,
+	/// number of the system call `get_processor_count`
+	GetProcessorCount = 7,
+	/// number of the system call `close`
+	Close = 8,
+	/// number of the system call `futex_wait`
+	FutexWait = 9,
+	/// number of the system call `futex_wake`
+	FutexWake = 10,
+	/// number of the system call `open`
+	Open = 11,
+	/// number of the system call `writev`
+	Writev = 12,
+	/// number of the system call `readv`
+	Readv = 13,
+}
+
+#[thread_local]
+static ERRNO: core::cell::UnsafeCell<i32> = core::cell::UnsafeCell::new(0);
+
+/// Get the last error number from the thread local storage
+#[no_mangle]
+pub extern "C" fn sys_get_errno() -> i32 {
+	unsafe { ERRNO.get().read() }
+}
+
+#[no_mangle]
+pub extern "C" fn sys_futex_wait(
+	address: *mut u32,
+	expected: u32,
+	timeout: *const abi::timespec,
+	flags: u32,
+) -> i32 {
+	let result: i32 = syscall!(SyscallNo::FutexWait, address, expected, timeout, flags)
+		.try_into()
+		.unwrap();
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_futex_wake(address: *mut u32, count: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::FutexWake, address, count)
+		.try_into()
+		.unwrap();
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+static MYPID: Lazy<RawSpinlock, u32> =
+	Lazy::new(|| syscall!(SyscallNo::Getpid).try_into().unwrap());
+
+#[no_mangle]
+pub extern "C" fn sys_getpid() -> u32 {
+	*MYPID
+}
+
+#[no_mangle]
+pub extern "C" fn sys_exit(arg: i32) -> ! {
+	syscall!(SyscallNo::Exit, arg);
+
+	unreachable!()
+}
+
+#[no_mangle]
+pub extern "C" fn sys_abort() -> ! {
+	sys_exit(1)
+}
+
+#[no_mangle]
+pub extern "C" fn sys_usleep(usecs: u64) {
+	syscall!(SyscallNo::Usleep, usecs);
+}
+
+#[no_mangle]
+pub extern "C" fn sys_spawn(
+	_id: *mut abi::Tid,
+	_func: extern "C" fn(usize),
+	_arg: usize,
+	_prio: u8,
+	_core_id: isize,
+) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_spawn2(
+	_func: extern "C" fn(usize),
+	_arg: usize,
+	_prio: u8,
+	_stack_size: usize,
+	_core_id: isize,
+) -> abi::Tid {
+	0
+}
+
+#[no_mangle]
+pub extern "C" fn sys_join(_id: abi::Tid) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_yield_now() {
+	syscall!(SyscallNo::Yield);
+}
+
+#[no_mangle]
+pub extern "C" fn sys_clock_gettime(_clock_id: u64, _tp: *mut abi::timespec) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_open(name: *const i8, flags: i32, mode: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Open, name, flags, mode)
+		.try_into()
+		.unwrap();
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_unlink(_name: *const i8) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_rmdir(_name: *const i8) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_stat(_name: *const i8, _stat: *mut abi::stat) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_lstat(_name: *const i8, _stat: *mut abi::stat) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_fstat(_fd: i32, _stat: *mut abi::stat) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_get_processor_count() -> usize {
+	syscall!(SyscallNo::GetProcessorCount).try_into().unwrap()
+}
+
+#[no_mangle]
+pub extern "C" fn sys_notify(_id: usize, _count: i32) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_add_queue(_id: usize, _timeout_ns: i64) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_wait(_id: usize) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_init_queue(_id: usize) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_destroy_queue(_id: usize) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_block_current_task() {}
+
+#[no_mangle]
+pub extern "C" fn sys_block_current_task_with_timeout(_timeout: u64) {}
+
+#[no_mangle]
+pub extern "C" fn sys_wakeup_task(_tid: abi::Tid) {}
+
+#[no_mangle]
+pub extern "C" fn sys_accept(
+	_s: i32,
+	_addr: *mut abi::sockaddr,
+	_addrlen: *mut abi::socklen_t,
+) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_bind(_s: i32, _name: *const abi::sockaddr, _namelen: abi::socklen_t) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_connect(
+	_s: i32,
+	_name: *const abi::sockaddr,
+	_namelen: abi::socklen_t,
+) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_read(fd: i32, buf: *mut u8, len: usize) -> isize {
+	let result: isize = syscall!(SyscallNo::Read, fd, buf, len).try_into().unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write((-result).try_into().unwrap());
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_readv(fd: i32, iov: *const u8, iovcnt: usize) -> isize {
+	let result: isize = syscall!(SyscallNo::Readv, fd, iov, iovcnt)
+		.try_into()
+		.unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write((-result).try_into().unwrap());
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_mkdir(_name: *const i8, _mode: u32) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_read_entropy(buf: *mut u8, len: usize, flags: u32) -> isize {
+	let result: isize = syscall!(SyscallNo::ReadEntropy, buf, len, flags)
+		.try_into()
+		.unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write((-result).try_into().unwrap());
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_recv(_socket: i32, _buf: *mut u8, _len: usize, _flags: i32) -> isize {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_recvfrom(
+	_socket: i32,
+	_buf: *mut u8,
+	_len: usize,
+	_flags: i32,
+	_addr: *mut abi::sockaddr,
+	_addrlen: *mut abi::socklen_t,
+) -> isize {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_write(fd: i32, buf: *const u8, len: usize) -> isize {
+	let result: isize = syscall!(SyscallNo::Write, fd, buf, len).try_into().unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write((-result).try_into().unwrap());
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_writev(fd: i32, iov: *const u8, iovcnt: usize) -> isize {
+	let result: isize = syscall!(SyscallNo::Writev, fd, iov, iovcnt)
+		.try_into()
+		.unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write((-result).try_into().unwrap());
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_close(fd: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Close, fd).try_into().unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_dup(_fd: i32) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_getpeername(
+	_s: i32,
+	_name: *mut abi::sockaddr,
+	_namelen: *mut abi::socklen_t,
+) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_getsockname(
+	_s: i32,
+	_name: *mut abi::sockaddr,
+	_namelen: *mut abi::socklen_t,
+) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_getsockopt(
+	_s: i32,
+	_level: i32,
+	_optname: i32,
+	_optval: *mut c_void,
+	_optlen: *mut abi::socklen_t,
+) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_setsockopt(
+	_s: i32,
+	_level: i32,
+	_optname: i32,
+	_optval: *const c_void,
+	_optlen: abi::socklen_t,
+) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_ioctl(_s: i32, _cmd: i32, _argp: *mut c_void) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_poll(_fds: *mut abi::pollfd, _nfds: abi::nfds_t, _timeout: i32) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_listen(_s: i32, _backlog: i32) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_send(_s: i32, _mem: *const c_void, _len: usize, _flags: i32) -> isize {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_sendto(
+	_s: i32,
+	_mem: *const c_void,
+	_len: usize,
+	_flags: i32,
+	_to: *const abi::sockaddr,
+	_tolen: abi::socklen_t,
+) -> isize {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_shutdown(_s: i32, _how: i32) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_socket(_domain: i32, _type_: i32, _protocol: i32) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub extern "C" fn sys_freeaddrinfo(_ai: *mut abi::addrinfo) {}
+
+#[no_mangle]
+pub extern "C" fn sys_getaddrinfo(
+	_nodename: *const i8,
+	_servname: *const u8,
+	_res: *mut *mut abi::addrinfo,
+) -> i32 {
+	-22
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn _start(_argc: i32, _argv: *const *const c_char) -> ! {
+	extern "C" {
+		fn runtime_entry(argc: i32, argv: *const *const c_char, env: *const *const c_char) -> !;
+	}
+
+	let environ = core::ptr::null::<*const c_char>();
+	let argv = [c"dummy".as_ptr()];
+
+	// And finally start the application.
+	runtime_entry(1, argv.as_ptr(), environ)
+}

--- a/hermit/src/syscall/x86_64.rs
+++ b/hermit/src/syscall/x86_64.rs
@@ -1,0 +1,188 @@
+use core::arch::asm;
+
+/// This macro can be used to call system functions from user-space
+#[macro_export]
+macro_rules! syscall {
+	($arg0:expr) => {
+		$crate::syscall::x86_64::syscall0($arg0 as u64)
+	};
+
+	($arg0:expr, $arg1:expr) => {
+		$crate::syscall::x86_64::syscall1($arg0 as u64, $arg1 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr) => {
+		$crate::syscall::x86_64::syscall2($arg0 as u64, $arg1 as u64, $arg2 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr) => {
+		$crate::syscall::x86_64::syscall3($arg0 as u64, $arg1 as u64, $arg2 as u64, $arg3 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr) => {
+		$crate::syscall::x86_64::syscall4(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+		)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
+		$crate::syscall::x86_64::syscall5(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+			$arg5 as u64,
+		)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr, $arg6:expr) => {
+		$crate::syscall::x86_64::syscall6(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+			$arg5 as u64,
+			$arg6 as u64,
+		)
+	};
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall0(arg0: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!("syscall",
+			inlateout("rax") arg0 => ret,
+			lateout("rcx") _,
+			lateout("r11") _,
+			options(preserves_flags, nostack)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall1(arg0: u64, arg1: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!("syscall",
+			inlateout("rax") arg0 => ret,
+			in("rdi") arg1,
+			lateout("rcx") _,
+			lateout("r11") _,
+			options(preserves_flags, nostack)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall2(arg0: u64, arg1: u64, arg2: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!("syscall",
+			inlateout("rax") arg0 => ret,
+			in("rdi") arg1,
+			in("rsi") arg2,
+			lateout("rcx") _,
+			lateout("r11") _,
+			options(preserves_flags, nostack)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall3(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!("syscall",
+			inlateout("rax") arg0 => ret,
+			in("rdi") arg1,
+			in("rsi") arg2,
+			in("rdx") arg3,
+			lateout("rcx") _,
+			lateout("r11") _,
+			options(preserves_flags, nostack)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall4(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!("syscall",
+			inlateout("rax") arg0 => ret,
+			in("rdi") arg1,
+			in("rsi") arg2,
+			in("rdx") arg3,
+			in("r10") arg4,
+			lateout("rcx") _,
+			lateout("r11") _,
+			options(preserves_flags, nostack)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall5(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!("syscall",
+			inlateout("rax") arg0 => ret,
+			in("rdi") arg1,
+			in("rsi") arg2,
+			in("rdx") arg3,
+			in("r10") arg4,
+			in("r8") arg5,
+			lateout("rcx") _,
+			lateout("r11") _,
+			options(preserves_flags, nostack)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall6(
+	arg0: u64,
+	arg1: u64,
+	arg2: u64,
+	arg3: u64,
+	arg4: u64,
+	arg5: u64,
+	arg6: u64,
+) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!("syscall",
+			inlateout("rax") arg0 => ret,
+			in("rdi") arg1,
+			in("rsi") arg2,
+			in("rdx") arg3,
+			in("r10") arg4,
+			in("r8") arg5,
+			in("r9") arg6,
+			lateout("rcx") _,
+			lateout("r11") _,
+			options(preserves_flags, nostack)
+		);
+	}
+	ret
+}


### PR DESCRIPTION
To build such applications, the feature "common-os" has to be enabled. For instance, the following command build `hello_world` for a monolithic OS.
    
`cargo build -Zbuild-std=std,panic_abort -Zbuild-std-features=compiler-builtins-mem --target x86_64-unknown-hermit -p hello_world --features hermit/common-os`