### PR TITLE
fix(build.rs): use canonical `cargo_home` location

### DIFF
--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -69,5 +69,6 @@ common-os = ["hermit-abi", "generic_once_cell", "libm", "spinning_top", "take-st
 [build-dependencies]
 cc = "1"
 flate2 = "1"
+home = "0.5"
 ureq = "3"
 tar = "0.4"

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -199,7 +199,7 @@ fn cargo() -> Command {
 		let exe = format!("cargo{}", env::consts::EXE_SUFFIX);
 		// On windows, the userspace toolchain ends up in front of the rustup proxy in $PATH.
 		// To reach the rustup proxy nonetheless, we explicitly query $CARGO_HOME.
-		let mut cargo_home = PathBuf::from(env::var_os("CARGO_HOME").unwrap());
+		let mut cargo_home = home::cargo_home().unwrap();
 		cargo_home.push("bin");
 		cargo_home.push(&exe);
 		if cargo_home.exists() {


### PR DESCRIPTION
See https://github.com/hermit-os/kernel/pull/1539.