### PR TITLE
feat(netbench): print bandwidth for each round

### DIFF
--- a/benches/netbench/src/rust-tcp-bw/client.rs
+++ b/benches/netbench/src/rust-tcp-bw/client.rs
@@ -12,17 +12,15 @@ fn main() {
 	let args = Config::parse();
 
 	println!("Connecting to the server {}...", args.address);
-	let n_rounds = args.n_rounds;
-	let n_bytes = args.n_bytes;
 
 	if let Ok(mut stream) = connection::client_connect(args.address_and_port()) {
 		connection::setup(&args, &stream);
 		println!("Connection established! Ready to send...");
 
 		// Create a buffer of 0s, size n_bytes, to be sent over multiple times
-		let buf = vec![0; n_bytes];
+		let buf = vec![0; args.n_bytes];
 
-		for _i in 0..n_rounds {
+		for _i in 0..args.n_rounds {
 			let mut pos = 0;
 
 			while pos < buf.len() {

--- a/benches/netbench/src/rust-tcp-bw/server.rs
+++ b/benches/netbench/src/rust-tcp-bw/server.rs
@@ -11,10 +11,9 @@ use rust_tcp_io_perf::{connection, print_utils};
 
 fn main() {
 	let args = Config::parse();
-	let n_bytes = args.n_bytes;
 	let tot_bytes = args.n_rounds * args.n_bytes;
 
-	let mut buf = vec![0; n_bytes];
+	let mut buf = vec![0; args.n_bytes];
 
 	let mut stream = connection::server_listen_and_get_first_connection(&args.port.to_string());
 	connection::setup(&args, &stream);

--- a/benches/netbench/src/rust-tcp-bw/server.rs
+++ b/benches/netbench/src/rust-tcp-bw/server.rs
@@ -19,8 +19,14 @@ fn main() {
 	connection::setup(&args, &stream);
 
 	let start = Instant::now();
-	for _i in 0..args.n_rounds {
+	for i in 0..args.n_rounds {
+		print!("round {i}: ");
+		let round_start = Instant::now();
 		stream.read_exact(&mut buf).unwrap();
+		let round_end = Instant::now();
+		let duration = round_end.duration_since(round_start);
+		let mbits = buf.len() as f64 * 8.0f64 / (1024.0f64 * 1024.0f64 * duration.as_secs_f64());
+		println!("{mbits} Mbit/s");
 	}
 	let end = Instant::now();
 	let duration = end.duration_since(start);


### PR DESCRIPTION
This should make interactive usage much more useful.