### PR TITLE
bench(alloc): Reduce size of allocations for 8GB runner compatability

### DIFF
--- a/benches/alloc/src/main.rs
+++ b/benches/alloc/src/main.rs
@@ -94,7 +94,7 @@ fn benchmark_allocator() -> BenchRunResults {
 	// run for 10s
 	let bench_begin_time = Instant::now();
 	while bench_begin_time.elapsed().as_secs_f64() <= BENCH_DURATION {
-		let size = fastrand::usize((1 << 6)..(1 << 16));
+		let size = fastrand::usize((1 << 6)..(1 << 15));
 		let align = 8 << (fastrand::u16(..).trailing_zeros() / 2);
 		let layout = Layout::from_size_align(size, align).unwrap();
 


### PR DESCRIPTION
Halves the allocation size, should fix https://github.com/hermit-os/kernel/pull/1726 pipeline