### PR TITLE
fix(netbench): restore `./run.sh`

### DIFF
--- a/benches/netbench/run.sh
+++ b/benches/netbench/run.sh
@@ -8,7 +8,6 @@ set -o errexit
 
 netbench_dir="${0%/*}"
 root_dir="$netbench_dir"/../..
-loader_dir="$root_dir"/hermit-loader-x86_64
 
 bin=$2
 args="--bytes 1048576 --rounds 1000"
@@ -16,18 +15,20 @@ args="--bytes 1048576 --rounds 1000"
 hermit() {
     echo "Building $bin image"
 
-    cargo -Zbuild-std=std,panic_abort build --manifest-path "$netbench_dir"/Cargo.toml --bin $bin \
-        --release --target x86_64-unknown-hermit
+    cargo build --manifest-path "$netbench_dir"/Cargo.toml --bin $bin \
+        -Zbuild-std=core,alloc,std,panic_abort -Zbuild-std-features=compiler-builtins-mem \
+        --target x86_64-unknown-hermit \
+        --release
 
     echo "Launching $bin image on QEMU"
 
     qemu-system-x86_64 -cpu host \
             -enable-kvm -display none -smp 1 -m 1G -serial stdio \
-            -kernel "$loader_dir" \
+            -kernel "$root_dir"/kernel/hermit-loader-x86_64 \
             -initrd "$root_dir"/target/x86_64-unknown-hermit/release/$bin \
             -netdev tap,id=net0,ifname=tap10,script=no,downscript=no,vhost=on \
             -device virtio-net-pci,netdev=net0,disable-legacy=on \
-            -append "-- --nonblocking --address 10.0.5.1 $args"
+            -append "-- --address 10.0.5.1 $args"
 }
 
 linux() {
@@ -37,7 +38,7 @@ linux() {
         --release \
         --target x86_64-unknown-linux-gnu \
         -- \
-        --nonblocking --address 10.0.5.3 $args
+        --address 10.0.5.3 $args
 }
 
 $1


### PR DESCRIPTION
This restores netbench's `./run.sh` to the state of https://github.com/hermit-os/hermit-rs/pull/694, before https://github.com/hermit-os/hermit-rs/pull/708.

I assume during rebasing, the former PR has been ignored.