### PR TITLE
tv_nsec: Use i64 instead of i32 following POSIX.

### DIFF
--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -73,7 +73,7 @@ pub struct timespec {
 	/// seconds
 	pub tv_sec: time_t,
 	/// nanoseconds
-	pub tv_nsec: i32,
+	pub tv_nsec: i64,
 }
 
 #[repr(C)]


### PR DESCRIPTION
Updated in kernel in https://github.com/hermit-os/kernel/pull/1778