### PR TITLE
build(deps): regenerate `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,7 +1562,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "mutex"
+name = "mutex_benchmark"
 version = "0.0.0"
 dependencies = [
  "hermit",


### PR DESCRIPTION
This was forgotten in https://github.com/hermit-os/hermit-rs/pull/751.