### PR TITLE
hermit: Add virtio-net feature 

### DIFF
--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -66,6 +66,7 @@ tcp = []
 trace = []
 udp = []
 vga = []
+virtio-net = []
 vsock = []
 common-os = ["hermit-abi", "generic_once_cell", "libm", "spinning_top", "take-static", "talc"]
 

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -133,6 +133,7 @@ impl KernelSrc {
 				"trace",
 				"udp",
 				"vga",
+				"virtio-net",
 				"vsock",
 			]
 			.into_iter(),


### PR DESCRIPTION
https://github.com/hermit-os/kernel/pull/1825 makes virtio-net an optional feature.

This depends on the kernel PR and vice-versa.