### PR TITLE
feat: support aarch64_be

### DIFF
--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -75,8 +75,13 @@ impl KernelSrc {
 			"kernel manifest path `{}` does not exist",
 			manifest_path.display()
 		);
-		let arch = env::var_os("CARGO_CFG_TARGET_ARCH").unwrap();
+		let mut arch = env::var_os("CARGO_CFG_TARGET_ARCH").unwrap();
+		let endian = env::var_os("CARGO_CFG_TARGET_ENDIAN").unwrap();
 		let profile = env::var("PROFILE").expect("PROFILE was not set");
+
+		if arch == "aarch64" && endian == "big" {
+			arch = "aarch64_be".into();
+		}
 
 		let mut cargo = cargo();
 


### PR DESCRIPTION
Big endian ARM has `target_arch` as `aarch64`, so we need to also check the configured endianess to set the correct target for the kernel.