### PR TITLE
feat(netbench): automate TAP device setup

### DIFF
--- a/benches/netbench/run.sh
+++ b/benches/netbench/run.sh
@@ -27,7 +27,7 @@ hermit() {
             -enable-kvm -display none -smp 1 -m 1G -serial stdio \
             -kernel "$root_dir"/kernel/hermit-loader-x86_64 \
             -initrd "$root_dir"/target/x86_64-unknown-hermit/release/$bin \
-            -netdev tap,id=net0,ifname=tap10,script=no,downscript=no,vhost=on \
+            -netdev tap,id=net0,script="$root_dir"/kernel/xtask/hermit-ifup,vhost=on \
             -device virtio-net-pci,netdev=net0,disable-legacy=on \
             -append "-- --address 10.0.5.1 $args"
 }

--- a/benches/netbench/run.sh
+++ b/benches/netbench/run.sh
@@ -23,7 +23,7 @@ hermit() {
 
     echo "Launching $bin image on QEMU"
 
-    qemu-system-x86_64 -cpu host \
+    sudo qemu-system-x86_64 -cpu host \
             -enable-kvm -display none -smp 1 -m 1G -serial stdio \
             -kernel "$root_dir"/kernel/hermit-loader-x86_64 \
             -initrd "$root_dir"/target/x86_64-unknown-hermit/release/$bin \

--- a/benches/netbench/run.sh
+++ b/benches/netbench/run.sh
@@ -18,6 +18,7 @@ hermit() {
     cargo build --manifest-path "$netbench_dir"/Cargo.toml --bin $bin \
         -Zbuild-std=core,alloc,std,panic_abort -Zbuild-std-features=compiler-builtins-mem \
         --target x86_64-unknown-hermit \
+        --features hermit/virtio-net \
         --release
 
     echo "Launching $bin image on QEMU"


### PR DESCRIPTION
This uses the TAP script introduced in https://github.com/hermit-os/kernel/pull/1798.