### PR TITLE
feat: don't download and unpack kernel sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,12 +269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,32 +911,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "filetime"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -1133,7 +1105,6 @@ name = "hermit"
 version = "0.12.0"
 dependencies = [
  "cc",
- "flate2",
  "generic_once_cell",
  "hermit-abi 0.4.0",
  "home",
@@ -1141,8 +1112,6 @@ dependencies = [
  "spinning_top",
  "take-static",
  "talc",
- "tar",
- "ureq",
 ]
 
 [[package]]
@@ -1436,17 +1405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,7 +1493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2201,7 +2158,6 @@ checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.8",
  "subtle",
@@ -2418,12 +2374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,17 +2494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -2801,41 +2740,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "ureq-proto",
- "utf-8",
- "webpki-roots",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -3137,15 +3041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webserver"
 version = "0.0.0"
 dependencies = [
@@ -3433,16 +3328,6 @@ dependencies = [
  "curve25519-dalek",
  "rand_core",
  "zeroize",
-]
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
 ]
 
 [[package]]

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -80,7 +80,4 @@ vsock = []
 
 [build-dependencies]
 cc = "1"
-flate2 = "1"
 home = "0.5"
-ureq = "3"
-tar = "0.4"

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -2,9 +2,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, str};
 
-use flate2::read::GzDecoder;
-use tar::Archive;
-
 fn main() {
 	let targets_hermit =
 		env::var_os("CARGO_CFG_TARGET_OS").is_some_and(|target_os| target_os == "hermit");
@@ -16,7 +13,7 @@ fn main() {
 		return;
 	}
 
-	let kernel_src = KernelSrc::local().unwrap_or_else(KernelSrc::download);
+	let kernel_src = KernelSrc::get();
 
 	kernel_src.build();
 
@@ -43,39 +40,19 @@ struct KernelSrc {
 }
 
 impl KernelSrc {
-	fn local() -> Option<Self> {
+	fn get() -> Self {
 		if let Some(src_dir) = env::var_os("HERMIT_MANIFEST_DIR") {
 			assert!(
 				!src_dir.is_empty(),
 				"HERMIT_MANIFEST_DIR is set to the empty string"
 			);
 			let src_dir = PathBuf::from(src_dir);
-			return Some(Self { src_dir });
+			return Self { src_dir };
 		}
 
 		let mut src_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
 		src_dir.set_file_name("kernel");
-		src_dir.exists().then_some(Self { src_dir })
-	}
-
-	fn download() -> Self {
-		let version = "0.12.0";
-		let out_dir = out_dir();
-		let src_dir = out_dir.join(format!("kernel-{version}"));
-
-		if !src_dir.exists() {
-			let url =
-				format!("https://github.com/hermit-os/kernel/archive/refs/tags/v{version}.tar.gz");
-			let response = ureq::get(url.as_str())
-				.call()
-				.unwrap()
-				.into_body()
-				.into_reader();
-			let tar = GzDecoder::new(response);
-			let mut archive = Archive::new(tar);
-			archive.unpack(src_dir.parent().unwrap()).unwrap();
-		}
-
+		assert!(src_dir.exists(), "could not find kernel source");
 		Self { src_dir }
 	}
 


### PR DESCRIPTION
This PR removes downloading and unpacking external kernel sources from the hermit wrapper crate. This means that the Hermit wrapper crate will no longer be published on crates.io but will need to be used via git.

Users will need to upgrade like this:

```diff
-hermit = "0.12"
+hermit = { git = "https://github.com/hermit-os/hermit-rs.git", tag = "hermit-0.13.0" }
```

### Comparison

This was tested in https://github.com/hermit-os/hermit-rs-template/pull/88:

- Downloaded dependencies for the wrapper crate
  - Before: 33
  - After: 4
- Time to download dependencies for the wrapper crate
  - Before: 1s (does not include kernel sources)
  - After: 4s (does include kernel sources)
- lockfile of the application
  - Before: 55 packages, 463 lines
  - After: 8 packages, 66 lines
- Building an application with the dev profile cleanly
  - Before: 1m 50s
  - After: 1m 26s
- Building an application with the release profile after the step above
  - Before: 1m 20s
  - After: 1m 8s

### Evaluation

#### Downsides

- The Hermit dependency becomes longer to type.
- Applications cannot be published to crates.io with git dependencies.

#### Upsides

- We put 47 fewer dependencies into application lockfiles.
- Clean building 20% faster on CI.
- Clean building works without network connection.
- We don't need to implement HTTP retry handling ourselves to be reliable.
- We don't break the crates.io rule about depending on code outside of crates.io anymore.
