### PR TITLE
add basic support of the system calls 'fork' and 'spawn_process'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pipe"
+version = "0.0.0"
+dependencies = [
+ "hermit",
+ "hermit-abi 0.5.2",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fork"
+version = "0.0.0"
+dependencies = [
+ "hermit",
+ "hermit-abi 0.5.2",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,19 +1136,13 @@ version = "0.13.2"
 dependencies = [
  "cc",
  "generic_once_cell",
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "home",
  "libm",
  "spinning_top",
  "take-static",
  "talc",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "getpid"
+version = "0.0.0"
+dependencies = [
+ "hermit",
+ "hermit-abi 0.5.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "false"
+version = "0.0.0"
+dependencies = [
+ "hermit",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,6 +2757,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "true"
+version = "0.0.0"
+dependencies = [
+ "hermit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,6 +2430,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "spawn"
+version = "0.0.0"
+dependencies = [
+ "hermit",
+ "hermit-abi 0.5.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "align-address"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee078b3ed87e2621e0389729e2f032cc0408a4548768ced01678c9451c62237"
+
+[[package]]
 name = "alloc_benchmarks"
 version = "0.0.0"
 dependencies = [
@@ -94,6 +100,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
 name = "android_system_properties"
@@ -305,7 +317,7 @@ version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
 ]
 
 [[package]]
@@ -1141,6 +1153,7 @@ dependencies = [
 name = "hermit"
 version = "0.13.2"
 dependencies = [
+ "align-address",
  "cc",
  "generic_once_cell",
  "hermit-abi 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1988,7 +2001,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "bumpalo",
  "hashbrown 0.17.0",
  "log",
@@ -2535,10 +2548,11 @@ dependencies = [
 
 [[package]]
 name = "talc"
-version = "4.4.3"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
+checksum = "3081e3f3ad542dc4cd0ae720f752598f8880fd364dc2d031132e3509f673aa23"
 dependencies = [
+ "allocator-api2 0.4.0",
  "lock_api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "benches/multithreaded",
     "examples/axum",
     "examples/demo",
+    "examples/fork",
     "examples/fuse_test",
     "examples/hello_world",
     "examples/httpd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "examples/mioudp",
     "examples/polling",
     "examples/rftrace-example",
+    "examples/spawn",
     "examples/stdin",
     "examples/testtcp",
     "examples/testudp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
     "examples/axum",
     "examples/demo",
     "examples/fork",
+    "examples/true",
+    "examples/false",
     "examples/fuse_test",
     "examples/hello_world",
     "examples/httpd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "examples/axum",
     "examples/demo",
     "examples/fork",
+    "examples/pipe",
     "examples/true",
     "examples/false",
     "examples/fuse_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "benches/mutex",
     "benches/startup",
     "benches/multithreaded",
+    "benches/getpid",
     "examples/axum",
     "examples/demo",
     "examples/fork",

--- a/benches/getpid/Cargo.toml
+++ b/benches/getpid/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "getpid"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+edition = "2021"
+
+[dependencies]
+hermit-abi = { path = "../../hermit-abi" }
+
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit = { path = "../../hermit", default-features = false }
+
+[features]
+default = ["hermit/acpi", "hermit/pci"]

--- a/benches/getpid/src/main.rs
+++ b/benches/getpid/src/main.rs
@@ -1,0 +1,28 @@
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+#[cfg(target_os = "hermit")]
+use hermit as _;
+use hermit_abi::getpid;
+
+fn getpid_bench(count: usize) -> Duration {
+	let start = Instant::now();
+	for _ in 0..count {
+		let _pid = black_box(unsafe { getpid() });
+	}
+	start.elapsed()
+}
+
+fn main() {
+	println!("Determine overhead of getpid...");
+
+	// warmup cache
+	let _ = getpid_bench(2);
+
+	let count = 10_0000_0000;
+	let result = black_box(getpid_bench(count));
+
+	println!("Number of iterations: {count}");
+	println!("Total time: {result:?}");
+	println!("Time per getpid: {:?}", result / count.try_into().unwrap());
+}

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -18,8 +18,8 @@ fn main() -> io::Result<()> {
 	thread::spawn()?;
 	fs::fs()?;
 	pi::pi();
-	matmul::matmul();
-	laplace::laplace();
+	//matmul::matmul();
+	//laplace::laplace();
 	mandelbrot::mandelbrot();
 	Ok(())
 }

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -18,8 +18,8 @@ fn main() -> io::Result<()> {
 	thread::spawn()?;
 	fs::fs()?;
 	pi::pi();
-	//matmul::matmul();
-	//laplace::laplace();
+	matmul::matmul();
+	laplace::laplace();
 	mandelbrot::mandelbrot();
 	Ok(())
 }

--- a/examples/false/Cargo.toml
+++ b/examples/false/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "false"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+edition = "2021"
+
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit = { path = "../../hermit", default-features = false }
+
+[features]
+default = ["hermit/acpi", "hermit/pci"]

--- a/examples/false/src/main.rs
+++ b/examples/false/src/main.rs
@@ -1,0 +1,6 @@
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+fn main() {
+	std::process::exit(1);
+}

--- a/examples/fork/Cargo.toml
+++ b/examples/fork/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fork"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+edition = "2021"
+
+[dependencies]
+hermit-abi = { path = "../../hermit-abi" }
+
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit = { path = "../../hermit", default-features = false }
+
+[features]
+default = ["hermit/acpi", "hermit/pci"]

--- a/examples/fork/src/main.rs
+++ b/examples/fork/src/main.rs
@@ -1,6 +1,32 @@
+use std::process::exit;
+use std::time::{Duration, Instant};
+
 #[cfg(target_os = "hermit")]
 use hermit as _;
-use hermit_abi::{fork, getpid, waitpid};
+use hermit_abi::{fork, getpid, waitpid, Pid};
+
+fn fork_bench(count: usize) -> Duration {
+	let mut pids = vec![Pid::default(); count]; // Pre-allocate with zeros
+
+	let start = Instant::now();
+	for i in 0..count {
+		let pid = unsafe { fork() };
+
+		if pid == 0 {
+			exit(0);
+		}
+		pids[i] = pid;
+	}
+
+	for pid in &pids {
+		unsafe {
+			waitpid(*pid);
+		}
+	}
+	let elapsed = start.elapsed();
+
+	elapsed
+}
 
 fn main() {
 	println!("Try to fork a process...");
@@ -18,7 +44,20 @@ fn main() {
 		unsafe {
 			waitpid(pid);
 		}
+
+		println!("Measure overhead of the system call fork.");
+
+		// warmup cache
+		let _ = fork_bench(2);
+
+		for i in 0..14 {
+			let count = 1 << i;
+			let result = fork_bench(count);
+			println!("Time to fork/join {count} processes: {result:?}");
+		}
 	} else {
 		println!("Unable to fork a process!");
 	}
+
+	println!("Leave program");
 }

--- a/examples/fork/src/main.rs
+++ b/examples/fork/src/main.rs
@@ -1,0 +1,24 @@
+#[cfg(target_os = "hermit")]
+use hermit as _;
+use hermit_abi::{fork, getpid, waitpid};
+
+fn main() {
+	println!("Try to fork a process...");
+
+	let pid = unsafe { fork() };
+	if pid == 0 {
+		println!("Hello from child process with id {}!", unsafe { getpid() });
+	} else if pid > 0 {
+		println!(
+			"Hello from parent process with id {}! Child has the id {}!",
+			unsafe { getpid() },
+			pid
+		);
+
+		unsafe {
+			waitpid(pid);
+		}
+	} else {
+		println!("Unable to fork a process!");
+	}
+}

--- a/examples/fork/src/main.rs
+++ b/examples/fork/src/main.rs
@@ -9,13 +9,12 @@ fn fork_bench(count: usize) -> Duration {
 	let mut pids = vec![Pid::default(); count]; // Pre-allocate with zeros
 
 	let start = Instant::now();
-	for i in 0..count {
-		let pid = unsafe { fork() };
+	for pid in pids.iter_mut().take(count) {
+		*pid = unsafe { fork() };
 
-		if pid == 0 {
+		if *pid == 0 {
 			exit(0);
 		}
-		pids[i] = pid;
 	}
 
 	for pid in &pids {
@@ -23,9 +22,8 @@ fn fork_bench(count: usize) -> Duration {
 			waitpid(*pid);
 		}
 	}
-	let elapsed = start.elapsed();
 
-	elapsed
+	start.elapsed()
 }
 
 fn main() {

--- a/examples/fork/src/main.rs
+++ b/examples/fork/src/main.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 #[cfg(target_os = "hermit")]
 use hermit as _;
-use hermit_abi::{fork, getpid, waitpid, Pid};
+use hermit_abi::{exec, fork, getpid, waitpid, Pid};
 
 fn fork_bench(count: usize) -> Duration {
 	let mut pids = vec![Pid::default(); count]; // Pre-allocate with zeros
@@ -34,6 +34,13 @@ fn main() {
 	let pid = unsafe { fork() };
 	if pid == 0 {
 		println!("Hello from child process with id {}!", unsafe { getpid() });
+
+		let app = c"/bin/hello_world";
+		unsafe {
+			let _ = exec(app.as_ptr());
+		}
+
+		println!("ERROR: Exec failed!!!");
 	} else if pid > 0 {
 		println!(
 			"Hello from parent process with id {}! Child has the id {}!",

--- a/examples/fork/src/main.rs
+++ b/examples/fork/src/main.rs
@@ -1,4 +1,3 @@
-use std::process::exit;
 use std::time::{Duration, Instant};
 
 #[cfg(target_os = "hermit")]
@@ -7,13 +6,17 @@ use hermit_abi::{exec, fork, getpid, waitpid, Pid};
 
 fn fork_bench(count: usize) -> Duration {
 	let mut pids = vec![Pid::default(); count]; // Pre-allocate with zeros
+	let app = c"/bin/true";
 
 	let start = Instant::now();
 	for pid in pids.iter_mut().take(count) {
 		*pid = unsafe { fork() };
 
 		if *pid == 0 {
-			exit(0);
+			//std::process::exit(0);
+			unsafe {
+				let _ = exec(app.as_ptr());
+			}
 		}
 	}
 

--- a/examples/fork/src/main.rs
+++ b/examples/fork/src/main.rs
@@ -15,7 +15,7 @@ fn fork_bench(count: usize) -> Duration {
 		if *pid == 0 {
 			//std::process::exit(0);
 			unsafe {
-				let _ = exec(app.as_ptr());
+				let _ = exec(app.as_ptr(), std::ptr::null(), std::ptr::null());
 			}
 		}
 	}
@@ -37,8 +37,12 @@ fn main() {
 		println!("Hello from child process with id {}!", unsafe { getpid() });
 
 		let app = c"/bin/hello_world";
+		// Pass an argument vector and an environment to the new
+		// process image; both arrays are NULL-terminated.
+		let argv = [app.as_ptr(), c"--from-exec".as_ptr(), std::ptr::null()];
+		let envp = [c"GREETING=Hello from exec!".as_ptr(), std::ptr::null()];
 		unsafe {
-			let _ = exec(app.as_ptr());
+			let _ = exec(app.as_ptr(), argv.as_ptr(), envp.as_ptr());
 		}
 
 		println!("ERROR: Exec failed!!!");

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -3,4 +3,11 @@ use hermit as _;
 
 fn main() {
 	println!("Hello, world!");
+
+	for (i, arg) in std::env::args().enumerate() {
+		println!("arg[{i}]: {arg}");
+	}
+	for (key, value) in std::env::vars() {
+		println!("env: {key}={value}");
+	}
 }

--- a/examples/pipe/Cargo.toml
+++ b/examples/pipe/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pipe"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+edition = "2021"
+
+[dependencies]
+hermit-abi = { path = "../../hermit-abi" }
+
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit = { path = "../../hermit", default-features = false }
+
+[features]
+default = ["hermit/acpi", "hermit/pci"]

--- a/examples/pipe/src/main.rs
+++ b/examples/pipe/src/main.rs
@@ -1,0 +1,85 @@
+//! Minimal demonstration of `pipe` + `fork`.
+//!
+//! The parent creates a pipe before forking. Because both pipe
+//! descriptors are inherited by the child, the two processes end up
+//! sharing the same in-kernel buffer: the child writes a message into the
+//! write end, the parent reads it back from the read end.
+//!
+//! Each process closes the end it does not use. Closing the child's write
+//! end is what lets the parent's read loop observe end-of-file (`read`
+//! returning 0) once the message has been consumed.
+
+#[cfg(target_os = "hermit")]
+use hermit as _;
+use hermit_abi::{close, exit, fork, getpid, pipe, read, waitpid, write};
+
+const MESSAGE: &[u8] = b"Hello from the child!";
+
+fn main() {
+	// `pipefd[0]` becomes the read end, `pipefd[1]` the write end.
+	let mut pipefd = [0i32; 2];
+	if unsafe { pipe(pipefd.as_mut_ptr()) } < 0 {
+		println!("Unable to create a pipe!");
+		return;
+	}
+	let [read_fd, write_fd] = pipefd;
+
+	let pid = unsafe { fork() };
+
+	if pid == 0 {
+		// --- child ---
+		// The child only writes, so it closes the read end first.
+		unsafe { close(read_fd) };
+
+		let mut written = 0;
+		while written < MESSAGE.len() {
+			let n = unsafe {
+				write(
+					write_fd,
+					MESSAGE[written..].as_ptr(),
+					MESSAGE.len() - written,
+				)
+			};
+			if n <= 0 {
+				break;
+			}
+			written += n as usize;
+		}
+
+		// Dropping the write end signals end-of-file to the reader.
+		unsafe { close(write_fd) };
+
+		// Terminate the child directly via the raw exit syscall, avoiding
+		// a std runtime tear-down in the forked address space.
+		unsafe { exit(0) };
+	} else if pid > 0 {
+		// --- parent ---
+		// The parent only reads, so it closes the write end. This is
+		// essential: as long as *any* write end is open the reader would
+		// never see end-of-file.
+		unsafe { close(write_fd) };
+
+		let mut buffer = [0u8; 128];
+		let mut received = Vec::new();
+		loop {
+			let n = unsafe { read(read_fd, buffer.as_mut_ptr(), buffer.len()) };
+			if n <= 0 {
+				// 0 == end-of-file (child closed the write end), < 0 == error.
+				break;
+			}
+			received.extend_from_slice(&buffer[..n as usize]);
+		}
+
+		unsafe { close(read_fd) };
+		unsafe { waitpid(pid) };
+
+		println!(
+			"Parent {} received from child {}: {:?}",
+			unsafe { getpid() },
+			pid,
+			String::from_utf8_lossy(&received),
+		);
+	} else {
+		println!("Unable to fork a process!");
+	}
+}

--- a/examples/spawn/Cargo.toml
+++ b/examples/spawn/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spawn"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+edition = "2021"
+
+[dependencies]
+hermit-abi = { path = "../../hermit-abi" }
+
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit = { path = "../../hermit", default-features = false }
+
+[features]
+default = ["hermit/acpi", "hermit/pci"]

--- a/examples/spawn/src/main.rs
+++ b/examples/spawn/src/main.rs
@@ -1,0 +1,19 @@
+#[cfg(target_os = "hermit")]
+use hermit as _;
+use hermit_abi::{spawn_process, waitpid};
+
+fn main() {
+	println!("Try to spawn a process...");
+
+	let app = c"/bin/hello_world";
+	let pid = unsafe { spawn_process(app.as_ptr()) };
+	if pid > 0 {
+		println!("Spawn process {app:?} with id {pid}!");
+
+		unsafe {
+			waitpid(pid);
+		}
+	} else {
+		println!("Unable to spawn a process!");
+	}
+}

--- a/examples/spawn/src/main.rs
+++ b/examples/spawn/src/main.rs
@@ -1,6 +1,30 @@
+use std::time::{Duration, Instant};
+
 #[cfg(target_os = "hermit")]
 use hermit as _;
-use hermit_abi::{spawn_process, waitpid};
+use hermit_abi::{spawn_process, waitpid, Pid};
+
+fn spawn_bench(count: usize) -> Duration {
+	let mut pids = vec![Pid::default(); count]; // Pre-allocate with zeros
+	let app = c"/bin/true";
+
+	let start = Instant::now();
+	for pid in pids.iter_mut().take(count) {
+		*pid = unsafe { spawn_process(app.as_ptr()) };
+
+		if *pid <= 0 {
+			println!("Unable to spawn a process!");
+		}
+	}
+
+	for pid in &pids {
+		unsafe {
+			waitpid(*pid);
+		}
+	}
+
+	start.elapsed()
+}
 
 fn main() {
 	println!("Try to spawn a process...");
@@ -15,5 +39,14 @@ fn main() {
 		}
 	} else {
 		println!("Unable to spawn a process!");
+	}
+
+	// warmup cache
+	let _ = spawn_bench(2);
+
+	for i in 0..14 {
+		let count = 1 << i;
+		let result = spawn_bench(count);
+		println!("Time to spawn/join {count} processes: {result:?}");
 	}
 }

--- a/examples/spawn/src/main.rs
+++ b/examples/spawn/src/main.rs
@@ -10,7 +10,7 @@ fn spawn_bench(count: usize) -> Duration {
 
 	let start = Instant::now();
 	for pid in pids.iter_mut().take(count) {
-		*pid = unsafe { spawn_process(app.as_ptr()) };
+		*pid = unsafe { spawn_process(app.as_ptr(), std::ptr::null(), std::ptr::null()) };
 
 		if *pid <= 0 {
 			println!("Unable to spawn a process!");
@@ -30,7 +30,11 @@ fn main() {
 	println!("Try to spawn a process...");
 
 	let app = c"/bin/hello_world";
-	let pid = unsafe { spawn_process(app.as_ptr()) };
+	// Pass an argument vector and an environment to the new process;
+	// both arrays are NULL-terminated.
+	let argv = [app.as_ptr(), c"--from-spawn".as_ptr(), std::ptr::null()];
+	let envp = [c"GREETING=Hello from spawn!".as_ptr(), std::ptr::null()];
+	let pid = unsafe { spawn_process(app.as_ptr(), argv.as_ptr(), envp.as_ptr()) };
 	if pid > 0 {
 		println!("Spawn process {app:?} with id {pid}!");
 

--- a/examples/true/Cargo.toml
+++ b/examples/true/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "true"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+edition = "2021"
+
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit = { path = "../../hermit", default-features = false }
+
+[features]
+default = ["hermit/acpi", "hermit/pci"]

--- a/examples/true/src/main.rs
+++ b/examples/true/src/main.rs
@@ -1,0 +1,6 @@
+#[cfg(target_os = "hermit")]
+use hermit as _;
+
+fn main() {
+	std::process::exit(0);
+}

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -902,6 +902,12 @@ extern "C" {
 	#[link_name = "sys_fork"]
 	pub fn fork() -> Pid;
 
+	/// spawn_process crend the path to the binary
+	/// is given by `name`ates a new process and the path to the binary
+	/// is given by `name`
+	#[link_name = "sys_spawn_process"]
+	pub fn spawn_process(name: *const c_char) -> Pid;
+
 	/// Wait for the termination of process `pid`
 	#[link_name = "sys_waitpid"]
 	pub fn waitpid(pid: Pid);

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -17,6 +17,9 @@ pub use self::errno::*;
 /// A thread handle type
 pub type Tid = u32;
 
+/// A process handle type
+pub type Pid = i32;
+
 /// Maximum number of priorities
 pub const NO_PRIORITIES: usize = 31;
 
@@ -893,6 +896,15 @@ extern "C" {
 		hints: *const addrinfo,
 		res: *mut *mut addrinfo,
 	) -> i32;
+
+	/// fork() causes creation of a new process.  The new process (child process) is
+	/// an exact copy of the calling process (parent process)
+	#[link_name = "sys_fork"]
+	pub fn fork() -> Pid;
+
+	/// Wait for the termination of process `pid`
+	#[link_name = "sys_waitpid"]
+	pub fn waitpid(pid: Pid);
 
 	fn sys_get_priority() -> u8;
 	fn sys_set_priority(tid: Tid, prio: u8);

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -912,6 +912,11 @@ extern "C" {
 	#[link_name = "sys_waitpid"]
 	pub fn waitpid(pid: Pid);
 
+	/// The function sys_exec function replace the current process image
+	/// with a new process image.
+	#[link_name = "sys_exec"]
+	pub fn exec(path: *const c_char) -> i32;
+
 	fn sys_get_priority() -> u8;
 	fn sys_set_priority(tid: Tid, prio: u8);
 }

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -902,20 +902,30 @@ extern "C" {
 	#[link_name = "sys_fork"]
 	pub fn fork() -> Pid;
 
-	/// spawn_process crend the path to the binary
-	/// is given by `name`ates a new process and the path to the binary
-	/// is given by `name`
+	/// spawn_process creates a new process. The path to the binary is
+	/// given by `name`. `argv` and `envp` are optional NULL-terminated
+	/// arrays of C strings defining the argument vector and the
+	/// environment of the new process. If `argv` is null, the new
+	/// process gets `[name]` as its argument vector.
 	#[link_name = "sys_spawn_process"]
-	pub fn spawn_process(name: *const c_char) -> Pid;
+	pub fn spawn_process(
+		name: *const c_char,
+		argv: *const *const c_char,
+		envp: *const *const c_char,
+	) -> Pid;
 
 	/// Wait for the termination of process `pid`
 	#[link_name = "sys_waitpid"]
 	pub fn waitpid(pid: Pid);
 
 	/// The function sys_exec function replace the current process image
-	/// with a new process image.
+	/// with a new process image. `argv` and `envp` are optional
+	/// NULL-terminated arrays of C strings defining the argument vector
+	/// and the environment of the new process image. If `argv` is null,
+	/// the new image gets `[path]` as its argument vector.
 	#[link_name = "sys_exec"]
-	pub fn exec(path: *const c_char) -> i32;
+	pub fn exec(path: *const c_char, argv: *const *const c_char, envp: *const *const c_char)
+		-> i32;
 
 	fn sys_get_priority() -> u8;
 	fn sys_set_priority(tid: Tid, prio: u8);

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -799,6 +799,19 @@ extern "C" {
 	#[link_name = "sys_dup"]
 	pub fn dup(fd: i32) -> i32;
 
+	/// create a unidirectional pipe
+	///
+	/// `pipe` creates a pipe and stores two file descriptors in the array
+	/// `pipefd`: `pipefd[0]` refers to the read end, `pipefd[1]` to the
+	/// write end. Data written to the write end is buffered by the kernel
+	/// until it is read from the read end. Both descriptors are inherited
+	/// across `fork`, so a pipe can be used to communicate between a parent
+	/// and a child process.
+	///
+	/// Returns `0` on success or a negative error number on failure.
+	#[link_name = "sys_pipe"]
+	pub fn pipe(pipefd: *mut i32) -> i32;
+
 	#[link_name = "sys_getpeername"]
 	pub fn getpeername(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32;
 

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["os"]
 links = "hermit"
 
 [dependencies]
-hermit-abi = { version = "0.4", optional = true }
+hermit-abi = { version = "0.5", optional = true }
 generic_once_cell = { version = "0.1", optional = true }
 libm = { version = "0.2", optional = true }
 spinning_top = { version = "0.3", optional = true }

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -25,6 +25,7 @@ align-address = { version = "0.4", optional = true }
 [features]
 default = []
 common-os = [
+	"dep:align-address",
 	"dep:hermit-abi",
 	"dep:generic_once_cell",
 	"dep:libm",

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -32,10 +32,8 @@ common-os = [
 	"dep:take-static",
 	"dep:talc",
 ]
-<<<<<<< HEAD
-=======
+
 common-os = ["hermit-abi", "align-address", "generic_once_cell", "libm", "spinning_top", "take-static", "talc"]
->>>>>>> be76f60 (add basic support of sys_mmap for common-os)
 
 ## Links against libc.a.
 libc = []

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -33,8 +33,6 @@ common-os = [
 	"dep:talc",
 ]
 
-common-os = ["hermit-abi", "align-address", "generic_once_cell", "libm", "spinning_top", "take-static", "talc"]
-
 ## Links against libc.a.
 libc = []
 

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -19,7 +19,8 @@ generic_once_cell = { version = "0.1", optional = true }
 libm = { version = "0.2", optional = true }
 spinning_top = { version = "0.3", optional = true }
 take-static = { version = "0.1", optional = true }
-talc = { version = "4.4", default-features = false, features = ["lock_api"], optional = true }
+talc = { version = "5.0.3", default-features = false, optional = true  }
+align-address = { version = "0.4", optional = true }
 
 [features]
 default = []
@@ -31,6 +32,10 @@ common-os = [
 	"dep:take-static",
 	"dep:talc",
 ]
+<<<<<<< HEAD
+=======
+common-os = ["hermit-abi", "align-address", "generic_once_cell", "libm", "spinning_top", "take-static", "talc"]
+>>>>>>> be76f60 (add basic support of sys_mmap for common-os)
 
 ## Links against libc.a.
 libc = []

--- a/hermit/src/syscall/aarch64.rs
+++ b/hermit/src/syscall/aarch64.rs
@@ -1,0 +1,182 @@
+use core::arch::asm;
+
+/// This macro can be used to call system functions from user-space
+#[macro_export]
+macro_rules! syscall {
+	($arg0:expr) => {
+		$crate::syscall::aarch64::syscall0($arg0 as u64)
+	};
+
+	($arg0:expr, $arg1:expr) => {
+		$crate::syscall::aarch64::syscall1($arg0 as u64, $arg1 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr) => {
+		$crate::syscall::aarch64::syscall2($arg0 as u64, $arg1 as u64, $arg2 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr) => {
+		$crate::syscall::aarch64::syscall3($arg0 as u64, $arg1 as u64, $arg2 as u64, $arg3 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr) => {
+		$crate::syscall::aarch64::syscall4(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+		)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
+		$crate::syscall::aarch64::syscall5(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+			$arg5 as u64,
+		)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr, $arg6:expr) => {
+		$crate::syscall::aarch64::syscall6(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+			$arg5 as u64,
+			$arg6 as u64,
+		)
+	};
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall0(arg0: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"svc #0",
+			in("x8") arg0,
+			lateout("x0") ret,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall1(arg0: u64, arg1: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"svc #0",
+			in("x8") arg0,
+			inlateout("x0") arg1 => ret,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall2(arg0: u64, arg1: u64, arg2: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"svc #0",
+			in("x8") arg0,
+			inlateout("x0") arg1 => ret,
+			in("x1") arg2,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall3(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"svc #0",
+			in("x8") arg0,
+			inlateout("x0") arg1 => ret,
+			in("x1") arg2,
+			in("x2") arg3,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall4(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"svc #0",
+			in("x8") arg0,
+			inlateout("x0") arg1 => ret,
+			in("x1") arg2,
+			in("x2") arg3,
+			in("x3") arg4,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall5(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"svc #0",
+			in("x8") arg0,
+			inlateout("x0") arg1 => ret,
+			in("x1") arg2,
+			in("x2") arg3,
+			in("x3") arg4,
+			in("x4") arg5,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall6(
+	arg0: u64,
+	arg1: u64,
+	arg2: u64,
+	arg3: u64,
+	arg4: u64,
+	arg5: u64,
+	arg6: u64,
+) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"svc #0",
+			in("x8") arg0,
+			inlateout("x0") arg1 => ret,
+			in("x1") arg2,
+			in("x2") arg3,
+			in("x3") arg4,
+			in("x4") arg5,
+			in("x5") arg6,
+			options(preserves_flags)
+		);
+	}
+	ret
+}

--- a/hermit/src/syscall/allocator.rs
+++ b/hermit/src/syscall/allocator.rs
@@ -8,7 +8,7 @@ use talc::{ErrOnOom, Talc, Talck};
 
 static ALLOC: Lazy<RawSpinlock, Talck<RawSpinlock, ErrOnOom>> = Lazy::new(|| {
 	take_static::take_static! {
-		static MEM: [MaybeUninit<u8>; 0x1000] = [MaybeUninit::uninit(); 0x1000];
+		static MEM: [MaybeUninit<u8>; 0x10000] = [MaybeUninit::uninit(); 0x10000];
 	}
 
 	let mem = MEM.take().unwrap();

--- a/hermit/src/syscall/allocator.rs
+++ b/hermit/src/syscall/allocator.rs
@@ -1,30 +1,65 @@
 use core::alloc::Layout;
-use core::ptr::NonNull;
-use std::mem::MaybeUninit;
+use std::ptr::{null_mut, NonNull};
+use std::sync::atomic::{AtomicPtr, Ordering};
 
+use align_address::Align;
 use generic_once_cell::Lazy;
 use spinning_top::RawSpinlock;
-use talc::{ErrOnOom, Talc, Talck};
+use talc::source::Claim;
+use talc::TalcLock;
 
-static ALLOC: Lazy<RawSpinlock, Talck<RawSpinlock, ErrOnOom>> = Lazy::new(|| {
-	take_static::take_static! {
-		static MEM: [MaybeUninit<u8>; 0x10000] = [MaybeUninit::uninit(); 0x10000];
+const MIN_SIZE: usize = 1 * 1024 * 1024;
+
+static HEAP_END: AtomicPtr<u8> = AtomicPtr::new(null_mut());
+static ALLOC: Lazy<RawSpinlock, TalcLock<RawSpinlock, Claim>> = Lazy::new(|| {
+	let mut mem: *mut u8 = null_mut();
+
+	if unsafe {
+		crate::syscall::mmap(
+			MIN_SIZE,
+			hermit_abi::PROT_READ | hermit_abi::PROT_WRITE,
+			&mut mem,
+		)
+	} == 0
+	{
+		unsafe { HEAP_END.store(mem.offset(MIN_SIZE.try_into().unwrap()), Ordering::Relaxed) };
+		TalcLock::new(unsafe { Claim::new(mem, MIN_SIZE) })
+	} else {
+		panic!("Unable to initialize heap!");
 	}
-
-	let mem = MEM.take().unwrap();
-
-	let mut talc = Talc::new(talc::ErrOnOom);
-	unsafe {
-		talc.claim(mem.into()).unwrap();
-	}
-
-	Talck::new(talc)
 });
 
 #[no_mangle]
 pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
 	let layout = Layout::from_size_align(size, align).unwrap();
-	unsafe { ALLOC.lock().malloc(layout).unwrap().as_mut() }
+	unsafe {
+		if let Some(mut addr) = ALLOC.lock().allocate(layout) {
+			return addr.as_mut();
+		}
+		
+		let heap_end = HEAP_END.load(Ordering::Acquire);
+		let extend_size = size.align_up(MIN_SIZE);
+		let mut result: *mut u8 = heap_end;
+
+		if crate::syscall::mmap(
+			extend_size,
+			hermit_abi::PROT_READ | hermit_abi::PROT_WRITE,
+			&mut result,
+		) == 0
+		{
+			let mut new_heap_end = ALLOC.lock().extend(
+				NonNull::new_unchecked(heap_end),
+				heap_end.offset(extend_size.try_into().unwrap()),
+			);
+			HEAP_END.store(new_heap_end.as_mut(), Ordering::Release);
+
+			if let Some(mut addr) = ALLOC.lock().allocate(layout) {
+				return addr.as_mut();
+			}
+		}
+
+		std::ptr::null_mut()
+	}
 }
 
 #[no_mangle]
@@ -32,15 +67,13 @@ pub extern "C" fn sys_realloc(ptr: *mut u8, size: usize, align: usize, new_size:
 	unsafe {
 		let layout = Layout::from_size_align(size, align).unwrap();
 		if new_size > size {
-			ALLOC
-				.lock()
-				.grow(NonNull::new_unchecked(ptr), layout, new_size)
-				.unwrap()
-				.as_mut()
+			if ALLOC.lock().try_grow_in_place(ptr, layout, new_size) {
+				ptr
+			} else {
+				std::ptr::null_mut()
+			}
 		} else {
-			ALLOC
-				.lock()
-				.shrink(NonNull::new_unchecked(ptr), layout, new_size);
+			ALLOC.lock().shrink(ptr, layout, new_size);
 			ptr
 		}
 	}
@@ -50,6 +83,6 @@ pub extern "C" fn sys_realloc(ptr: *mut u8, size: usize, align: usize, new_size:
 pub extern "C" fn sys_free(ptr: *mut u8, size: usize, align: usize) {
 	let layout = Layout::from_size_align(size, align).unwrap();
 	unsafe {
-		ALLOC.lock().free(NonNull::new_unchecked(ptr), layout);
+		ALLOC.lock().deallocate(ptr, layout);
 	}
 }

--- a/hermit/src/syscall/allocator.rs
+++ b/hermit/src/syscall/allocator.rs
@@ -36,7 +36,7 @@ pub extern "C" fn sys_malloc(size: usize, align: usize) -> *mut u8 {
 		if let Some(mut addr) = ALLOC.lock().allocate(layout) {
 			return addr.as_mut();
 		}
-		
+
 		let heap_end = HEAP_END.load(Ordering::Acquire);
 		let extend_size = size.align_up(MIN_SIZE);
 		let mut result: *mut u8 = heap_end;

--- a/hermit/src/syscall/allocator.rs
+++ b/hermit/src/syscall/allocator.rs
@@ -8,7 +8,7 @@ use spinning_top::RawSpinlock;
 use talc::source::Claim;
 use talc::TalcLock;
 
-const MIN_SIZE: usize = 1 * 1024 * 1024;
+const MIN_SIZE: usize = 1024 * 1024;
 
 static HEAP_END: AtomicPtr<u8> = AtomicPtr::new(null_mut());
 static ALLOC: Lazy<RawSpinlock, TalcLock<RawSpinlock, Claim>> = Lazy::new(|| {

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -2,6 +2,9 @@ mod math;
 #[cfg(target_arch = "x86_64")]
 #[macro_use]
 pub(crate) mod x86_64;
+#[cfg(target_arch = "aarch64")]
+#[macro_use]
+pub(crate) mod aarch64;
 mod allocator;
 
 use core::ffi::{c_char, c_void};

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -121,6 +121,12 @@ pub(crate) enum SyscallNo {
 	Getaddrinfo = 52,
 	/// number of the system call `freeaddrinfo`
 	Freeaddrinfo = 53,
+	/// number of the system call `availale_parallelism`
+	AvailableParallelism = 54,
+	/// number of the system call `getdents64`
+	GetDents64 = 55,
+	/// number of the system call `exec`
+	Exec = 56,
 }
 
 #[thread_local]
@@ -642,8 +648,8 @@ pub unsafe extern "C" fn sys_fork() -> Pid {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sys_spawn_process(name: *const c_char) -> Pid {
-	let result: i32 = syscall!(SyscallNo::SpawnProcess, name).try_into().unwrap();
+pub unsafe extern "C" fn sys_spawn_process(path: *const c_char) -> Pid {
+	let result: i32 = syscall!(SyscallNo::SpawnProcess, path).try_into().unwrap();
 
 	if result < 0 {
 		unsafe {
@@ -656,4 +662,49 @@ pub unsafe extern "C" fn sys_spawn_process(name: *const c_char) -> Pid {
 	}
 
 	result as Pid
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sys_available_parallelism() -> usize {
+	syscall!(SyscallNo::AvailableParallelism)
+		.try_into()
+		.unwrap()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sys_getdents64(fd: i32, dirp: *mut abi::dirent64, count: usize) -> i64 {
+	let result: i64 = syscall!(SyscallNo::GetDents64, fd, dirp, count)
+		.try_into()
+		.unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write((-result).try_into().unwrap());
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sys_exec(path: *const c_char) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Exec, path).try_into().unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+
+		-1
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+
+		0
+	}
 }

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -208,7 +208,7 @@ pub extern "C" fn sys_spawn(
 	prio: u8,
 	core_id: isize,
 ) -> i32 {
-	let result: i32 = syscall!(SyscallNo::Spawn, id, func, arg, prio, core_id)
+	let result: i32 = syscall!(SyscallNo::Spawn, id, func as usize, arg, prio, core_id)
 		.try_into()
 		.unwrap();
 	update_errno!(result);
@@ -223,9 +223,16 @@ pub extern "C" fn sys_spawn2(
 	stack_size: usize,
 	core_id: isize,
 ) -> abi::Tid {
-	syscall!(SyscallNo::Spawn2, func, arg, prio, stack_size, core_id)
-		.try_into()
-		.unwrap()
+	syscall!(
+		SyscallNo::Spawn2,
+		func as usize,
+		arg,
+		prio,
+		stack_size,
+		core_id
+	)
+	.try_into()
+	.unwrap()
 }
 
 #[no_mangle]

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -47,6 +47,80 @@ pub(crate) enum SyscallNo {
 	Waitpid = 15,
 	/// number of the system call `spawn_process`
 	SpawnProcess = 16,
+	/// number of the system call `clock_gettime`
+	ClockGettime = 17,
+	/// number of the system call `spawn`
+	Spawn = 18,
+	/// number of the system call `spawn2`
+	Spawn2 = 19,
+	/// number of the system call `join`
+	Join = 20,
+	/// number of the system call `unlink`
+	Unlink = 21,
+	/// number of the system call `mkdir`
+	Mkdir = 22,
+	/// number of the system call `rmdir`
+	Rmdir = 23,
+	/// number of the system call `stat`
+	Stat = 24,
+	/// number of the system call `lstat`
+	Lstat = 25,
+	/// number of the system call `fstat`
+	Fstat = 26,
+	/// number of the system call `dup`
+	Dup = 27,
+	/// number of the system call `ioctl`
+	Ioctl = 28,
+	/// number of the system call `poll`
+	Poll = 29,
+	/// number of the system call `notify`
+	Notify = 30,
+	/// number of the system call `add_queue`
+	AddQueue = 31,
+	/// number of the system call `wait`
+	Wait = 32,
+	/// number of the system call `init_queue`
+	InitQueue = 33,
+	/// number of the system call `destroy_queue`
+	DestroyQueue = 34,
+	/// number of the system call `block_current_task`
+	BlockCurrentTask = 35,
+	/// number of the system call `block_current_task_with_timeout`
+	BlockCurrentTaskWithTimeout = 36,
+	/// number of the system call `wakeup_task`
+	WakeupTask = 37,
+	/// number of the system call `socket`
+	Socket = 38,
+	/// number of the system call `bind`
+	Bind = 39,
+	/// number of the system call `listen`
+	Listen = 40,
+	/// number of the system call `accept`
+	Accept = 41,
+	/// number of the system call `connect`
+	Connect = 42,
+	/// number of the system call `recv`
+	Recv = 43,
+	/// number of the system call `recvfrom`
+	Recvfrom = 44,
+	/// number of the system call `send`
+	Send = 45,
+	/// number of the system call `sendto`
+	Sendto = 46,
+	/// number of the system call `shutdown`
+	Shutdown = 47,
+	/// number of the system call `getpeername`
+	Getpeername = 48,
+	/// number of the system call `getsockname`
+	Getsockname = 49,
+	/// number of the system call `getsockopt`
+	Getsockopt = 50,
+	/// number of the system call `setsockopt`
+	Setsockopt = 51,
+	/// number of the system call `getaddrinfo`
+	Getaddrinfo = 52,
+	/// number of the system call `freeaddrinfo`
+	Freeaddrinfo = 53,
 }
 
 #[thread_local]
@@ -119,29 +193,37 @@ pub extern "C" fn sys_usleep(usecs: u64) {
 
 #[no_mangle]
 pub extern "C" fn sys_spawn(
-	_id: *mut abi::Tid,
-	_func: extern "C" fn(usize),
-	_arg: usize,
-	_prio: u8,
-	_core_id: isize,
+	id: *mut abi::Tid,
+	func: extern "C" fn(usize),
+	arg: usize,
+	prio: u8,
+	core_id: isize,
 ) -> i32 {
-	-22
+	let result: i32 = syscall!(SyscallNo::Spawn, id, func, arg, prio, core_id)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
 pub extern "C" fn sys_spawn2(
-	_func: extern "C" fn(usize),
-	_arg: usize,
-	_prio: u8,
-	_stack_size: usize,
-	_core_id: isize,
+	func: extern "C" fn(usize),
+	arg: usize,
+	prio: u8,
+	stack_size: usize,
+	core_id: isize,
 ) -> abi::Tid {
-	0
+	syscall!(SyscallNo::Spawn2, func, arg, prio, stack_size, core_id)
+		.try_into()
+		.unwrap()
 }
 
 #[no_mangle]
-pub extern "C" fn sys_join(_id: abi::Tid) -> i32 {
-	-22
+pub extern "C" fn sys_join(id: abi::Tid) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Join, id).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
@@ -150,8 +232,8 @@ pub extern "C" fn sys_yield() {
 }
 
 #[no_mangle]
-pub extern "C" fn sys_clock_gettime(_clock_id: u64, _tp: *mut abi::timespec) -> i32 {
-	-22
+pub extern "C" fn sys_clock_gettime(clock_id: u64, tp: *mut abi::timespec) -> i32 {
+	syscall!(SyscallNo::ClockGettime, clock_id, tp) as i32
 }
 
 #[no_mangle]
@@ -164,28 +246,38 @@ pub extern "C" fn sys_open(name: *const i8, flags: i32, mode: i32) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn sys_unlink(_name: *const i8) -> i32 {
-	-22
+pub extern "C" fn sys_unlink(name: *const i8) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Unlink, name).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_rmdir(_name: *const i8) -> i32 {
-	-22
+pub extern "C" fn sys_rmdir(name: *const i8) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Rmdir, name).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_stat(_name: *const i8, _stat: *mut abi::stat) -> i32 {
-	-22
+pub extern "C" fn sys_stat(name: *const i8, stat: *mut abi::stat) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Stat, name, stat).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_lstat(_name: *const i8, _stat: *mut abi::stat) -> i32 {
-	-22
+pub extern "C" fn sys_lstat(name: *const i8, stat: *mut abi::stat) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Lstat, name, stat).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_fstat(_fd: i32, _stat: *mut abi::stat) -> i32 {
-	-22
+pub extern "C" fn sys_fstat(fd: i32, stat: *mut abi::stat) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Fstat, fd, stat).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
@@ -194,60 +286,86 @@ pub extern "C" fn sys_get_processor_count() -> usize {
 }
 
 #[no_mangle]
-pub extern "C" fn sys_notify(_id: usize, _count: i32) -> i32 {
-	-22
+pub extern "C" fn sys_notify(id: usize, count: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Notify, id, count).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_add_queue(_id: usize, _timeout_ns: i64) -> i32 {
-	-22
+pub extern "C" fn sys_add_queue(id: usize, timeout_ns: i64) -> i32 {
+	let result: i32 = syscall!(SyscallNo::AddQueue, id, timeout_ns)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_wait(_id: usize) -> i32 {
-	-22
+pub extern "C" fn sys_wait(id: usize) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Wait, id).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_init_queue(_id: usize) -> i32 {
-	-22
+pub extern "C" fn sys_init_queue(id: usize) -> i32 {
+	let result: i32 = syscall!(SyscallNo::InitQueue, id).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_destroy_queue(_id: usize) -> i32 {
-	-22
+pub extern "C" fn sys_destroy_queue(id: usize) -> i32 {
+	let result: i32 = syscall!(SyscallNo::DestroyQueue, id).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_block_current_task() {}
+pub extern "C" fn sys_block_current_task() {
+	syscall!(SyscallNo::BlockCurrentTask);
+}
 
 #[no_mangle]
-pub extern "C" fn sys_block_current_task_with_timeout(_timeout: u64) {}
+pub extern "C" fn sys_block_current_task_with_timeout(timeout: u64) {
+	syscall!(SyscallNo::BlockCurrentTaskWithTimeout, timeout);
+}
 
 #[no_mangle]
-pub extern "C" fn sys_wakeup_task(_tid: abi::Tid) {}
+pub extern "C" fn sys_wakeup_task(tid: abi::Tid) {
+	syscall!(SyscallNo::WakeupTask, tid);
+}
 
 #[no_mangle]
 pub extern "C" fn sys_accept(
-	_s: i32,
-	_addr: *mut abi::sockaddr,
-	_addrlen: *mut abi::socklen_t,
+	s: i32,
+	addr: *mut abi::sockaddr,
+	addrlen: *mut abi::socklen_t,
 ) -> i32 {
-	-22
+	let result: i32 = syscall!(SyscallNo::Accept, s, addr, addrlen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_bind(_s: i32, _name: *const abi::sockaddr, _namelen: abi::socklen_t) -> i32 {
-	-22
+pub extern "C" fn sys_bind(s: i32, name: *const abi::sockaddr, namelen: abi::socklen_t) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Bind, s, name, namelen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_connect(
-	_s: i32,
-	_name: *const abi::sockaddr,
-	_namelen: abi::socklen_t,
-) -> i32 {
-	-22
+pub extern "C" fn sys_connect(s: i32, name: *const abi::sockaddr, namelen: abi::socklen_t) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Connect, s, name, namelen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
@@ -267,8 +385,10 @@ pub extern "C" fn sys_readv(fd: i32, iov: *const u8, iovcnt: usize) -> isize {
 }
 
 #[no_mangle]
-pub extern "C" fn sys_mkdir(_name: *const i8, _mode: u32) -> i32 {
-	-22
+pub extern "C" fn sys_mkdir(name: *const i8, mode: u32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Mkdir, name, mode).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
@@ -281,20 +401,28 @@ pub extern "C" fn sys_read_entropy(buf: *mut u8, len: usize, flags: u32) -> isiz
 }
 
 #[no_mangle]
-pub extern "C" fn sys_recv(_socket: i32, _buf: *mut u8, _len: usize, _flags: i32) -> isize {
-	-22
+pub extern "C" fn sys_recv(socket: i32, buf: *mut u8, len: usize, flags: i32) -> isize {
+	let result: isize = syscall!(SyscallNo::Recv, socket, buf, len, flags)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
 pub extern "C" fn sys_recvfrom(
-	_socket: i32,
-	_buf: *mut u8,
-	_len: usize,
-	_flags: i32,
-	_addr: *mut abi::sockaddr,
-	_addrlen: *mut abi::socklen_t,
+	socket: i32,
+	buf: *mut u8,
+	len: usize,
+	flags: i32,
+	addr: *mut abi::sockaddr,
+	addrlen: *mut abi::socklen_t,
 ) -> isize {
-	-22
+	let result: isize = syscall!(SyscallNo::Recvfrom, socket, buf, len, flags, addr, addrlen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
@@ -321,102 +449,149 @@ pub extern "C" fn sys_close(fd: i32) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn sys_dup(_fd: i32) -> i32 {
-	-22
+pub extern "C" fn sys_dup(fd: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Dup, fd).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
 pub extern "C" fn sys_getpeername(
-	_s: i32,
-	_name: *mut abi::sockaddr,
-	_namelen: *mut abi::socklen_t,
+	s: i32,
+	name: *mut abi::sockaddr,
+	namelen: *mut abi::socklen_t,
 ) -> i32 {
-	-22
+	let result: i32 = syscall!(SyscallNo::Getpeername, s, name, namelen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
 pub extern "C" fn sys_getsockname(
-	_s: i32,
-	_name: *mut abi::sockaddr,
-	_namelen: *mut abi::socklen_t,
+	s: i32,
+	name: *mut abi::sockaddr,
+	namelen: *mut abi::socklen_t,
 ) -> i32 {
-	-22
+	let result: i32 = syscall!(SyscallNo::Getsockname, s, name, namelen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
 pub extern "C" fn sys_getsockopt(
-	_s: i32,
-	_level: i32,
-	_optname: i32,
-	_optval: *mut c_void,
-	_optlen: *mut abi::socklen_t,
+	s: i32,
+	level: i32,
+	optname: i32,
+	optval: *mut c_void,
+	optlen: *mut abi::socklen_t,
 ) -> i32 {
-	-22
+	let result: i32 = syscall!(SyscallNo::Getsockopt, s, level, optname, optval, optlen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
 pub extern "C" fn sys_setsockopt(
-	_s: i32,
-	_level: i32,
-	_optname: i32,
-	_optval: *const c_void,
-	_optlen: abi::socklen_t,
+	s: i32,
+	level: i32,
+	optname: i32,
+	optval: *const c_void,
+	optlen: abi::socklen_t,
 ) -> i32 {
-	-22
+	let result: i32 = syscall!(SyscallNo::Setsockopt, s, level, optname, optval, optlen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_ioctl(_s: i32, _cmd: i32, _argp: *mut c_void) -> i32 {
-	-22
+pub extern "C" fn sys_ioctl(s: i32, cmd: i32, argp: *mut c_void) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Ioctl, s, cmd, argp).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_poll(_fds: *mut abi::pollfd, _nfds: abi::nfds_t, _timeout: i32) -> i32 {
-	-22
+pub extern "C" fn sys_poll(fds: *mut abi::pollfd, nfds: abi::nfds_t, timeout: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Poll, fds, nfds, timeout)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_listen(_s: i32, _backlog: i32) -> i32 {
-	-22
+pub extern "C" fn sys_listen(s: i32, backlog: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Listen, s, backlog).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_send(_s: i32, _mem: *const c_void, _len: usize, _flags: i32) -> isize {
-	-22
+pub extern "C" fn sys_send(s: i32, mem: *const c_void, len: usize, flags: i32) -> isize {
+	let result: isize = syscall!(SyscallNo::Send, s, mem, len, flags)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
 pub extern "C" fn sys_sendto(
-	_s: i32,
-	_mem: *const c_void,
-	_len: usize,
-	_flags: i32,
-	_to: *const abi::sockaddr,
-	_tolen: abi::socklen_t,
+	s: i32,
+	mem: *const c_void,
+	len: usize,
+	flags: i32,
+	to: *const abi::sockaddr,
+	tolen: abi::socklen_t,
 ) -> isize {
-	-22
+	let result: isize = syscall!(SyscallNo::Sendto, s, mem, len, flags, to, tolen)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_shutdown(_s: i32, _how: i32) -> i32 {
-	-22
+pub extern "C" fn sys_shutdown(s: i32, how: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Shutdown, s, how).try_into().unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_socket(_domain: i32, _type_: i32, _protocol: i32) -> i32 {
-	-22
+pub extern "C" fn sys_socket(domain: i32, type_: i32, protocol: i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Socket, domain, type_, protocol)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]
-pub extern "C" fn sys_freeaddrinfo(_ai: *mut abi::addrinfo) {}
+pub extern "C" fn sys_freeaddrinfo(ai: *mut abi::addrinfo) {
+	syscall!(SyscallNo::Freeaddrinfo, ai);
+}
 
 #[no_mangle]
 pub extern "C" fn sys_getaddrinfo(
-	_nodename: *const i8,
-	_servname: *const u8,
-	_res: *mut *mut abi::addrinfo,
+	nodename: *const i8,
+	servname: *const i8,
+	hints: *const abi::addrinfo,
+	res: *mut *mut abi::addrinfo,
 ) -> i32 {
-	-22
+	let result: i32 = syscall!(SyscallNo::Getaddrinfo, nodename, servname, hints, res)
+		.try_into()
+		.unwrap();
+	update_errno!(result);
+	result
 }
 
 #[no_mangle]

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -45,6 +45,8 @@ pub(crate) enum SyscallNo {
 	Fork = 14,
 	/// number of the system call `waitpid`
 	Waitpid = 15,
+	/// number of the system call `spawn_process`
+	SpawnProcess = 16,
 }
 
 #[thread_local]
@@ -449,7 +451,24 @@ pub unsafe extern "C" fn sys_waitpid(pid: Pid) -> i32 {
 
 #[no_mangle]
 pub unsafe extern "C" fn sys_fork() -> Pid {
-	let result = syscall!(SyscallNo::Fork) as Pid;
+	let result: i32 = syscall!(SyscallNo::Fork).try_into().unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result as Pid
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sys_spawn_process(name: *const c_char) -> Pid {
+	let result: i32 = syscall!(SyscallNo::SpawnProcess, name).try_into().unwrap();
 
 	if result < 0 {
 		unsafe {

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -10,6 +10,8 @@ use generic_once_cell::Lazy;
 use hermit_abi as abi;
 use spinning_top::RawSpinlock;
 
+pub type Pid = i32;
+
 pub(crate) enum SyscallNo {
 	/// number of the system call `exit`
 	Exit = 0,
@@ -39,6 +41,10 @@ pub(crate) enum SyscallNo {
 	Writev = 12,
 	/// number of the system call `readv`
 	Readv = 13,
+	/// number of the system call `fork`
+	Fork = 14,
+	/// number of the system call `waitpid`
+	Waitpid = 15,
 }
 
 #[thread_local]
@@ -137,7 +143,7 @@ pub extern "C" fn sys_join(_id: abi::Tid) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn sys_yield_now() {
+pub extern "C" fn sys_yield() {
 	syscall!(SyscallNo::Yield);
 }
 
@@ -422,4 +428,38 @@ pub unsafe extern "C" fn _start(_argc: i32, _argv: *const *const c_char) -> ! {
 
 	// And finally start the application.
 	runtime_entry(1, argv.as_ptr(), environ)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sys_waitpid(pid: Pid) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Waitpid, pid).try_into().unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sys_fork() -> Pid {
+	let result = syscall!(SyscallNo::Fork) as Pid;
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+	}
+
+	result as Pid
 }

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -130,6 +130,8 @@ pub(crate) enum SyscallNo {
 	GetDents64 = 55,
 	/// number of the system call `exec`
 	Exec = 56,
+	/// number of the system call `mmap`
+	Mmap = 57,
 }
 
 #[thread_local]
@@ -703,6 +705,32 @@ pub unsafe extern "C" fn sys_getdents64(fd: i32, dirp: *mut abi::dirent64, count
 #[no_mangle]
 pub unsafe extern "C" fn sys_exec(path: *const c_char) -> i32 {
 	let result: i32 = syscall!(SyscallNo::Exec, path).try_into().unwrap();
+
+	if result < 0 {
+		unsafe {
+			ERRNO.get().write(-result);
+		}
+
+		-1
+	} else {
+		unsafe {
+			ERRNO.get().write(0);
+		}
+
+		0
+	}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn mmap(size: usize, prot_flags: u32, ret: &mut *mut u8) -> i32 {
+	let result: i32 = syscall!(
+		SyscallNo::Mmap,
+		size,
+		prot_flags,
+		ret as *mut *mut _ as usize
+	)
+	.try_into()
+	.unwrap();
 
 	if result < 0 {
 		unsafe {

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -5,6 +5,9 @@ pub(crate) mod x86_64;
 #[cfg(target_arch = "aarch64")]
 #[macro_use]
 pub(crate) mod aarch64;
+#[cfg(target_arch = "riscv64")]
+#[macro_use]
+pub(crate) mod riscv64;
 mod allocator;
 
 use core::ffi::{c_char, c_void};

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -613,16 +613,25 @@ pub extern "C" fn sys_getaddrinfo(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn _start(_argc: i32, _argv: *const *const c_char) -> ! {
+pub unsafe extern "C" fn _start(
+	argc: i32,
+	argv: *const *const c_char,
+	env: *const *const c_char,
+) -> ! {
 	extern "C" {
 		fn runtime_entry(argc: i32, argv: *const *const c_char, env: *const *const c_char) -> !;
 	}
 
-	let environ = core::ptr::null::<*const c_char>();
-	let argv = [c"dummy".as_ptr()];
+	// The kernel passes `argc`, a NULL-terminated `argv` array, and a
+	// NULL-terminated `env` array on the user stack. Fall back to a
+	// dummy argument vector if no arguments were handed over.
+	if argv.is_null() || argc <= 0 {
+		let argv = [c"dummy".as_ptr(), core::ptr::null()];
+		runtime_entry(1, argv.as_ptr(), env)
+	}
 
 	// And finally start the application.
-	runtime_entry(1, argv.as_ptr(), environ)
+	runtime_entry(argc, argv, env)
 }
 
 #[no_mangle]
@@ -660,8 +669,14 @@ pub unsafe extern "C" fn sys_fork() -> Pid {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sys_spawn_process(path: *const c_char) -> Pid {
-	let result: i32 = syscall!(SyscallNo::SpawnProcess, path).try_into().unwrap();
+pub unsafe extern "C" fn sys_spawn_process(
+	path: *const c_char,
+	argv: *const *const c_char,
+	envp: *const *const c_char,
+) -> Pid {
+	let result: i32 = syscall!(SyscallNo::SpawnProcess, path, argv, envp)
+		.try_into()
+		.unwrap();
 
 	if result < 0 {
 		unsafe {
@@ -703,8 +718,14 @@ pub unsafe extern "C" fn sys_getdents64(fd: i32, dirp: *mut abi::dirent64, count
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sys_exec(path: *const c_char) -> i32 {
-	let result: i32 = syscall!(SyscallNo::Exec, path).try_into().unwrap();
+pub unsafe extern "C" fn sys_exec(
+	path: *const c_char,
+	argv: *const *const c_char,
+	envp: *const *const c_char,
+) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Exec, path, argv, envp)
+		.try_into()
+		.unwrap();
 
 	if result < 0 {
 		unsafe {

--- a/hermit/src/syscall/mod.rs
+++ b/hermit/src/syscall/mod.rs
@@ -135,6 +135,8 @@ pub(crate) enum SyscallNo {
 	Exec = 56,
 	/// number of the system call `mmap`
 	Mmap = 57,
+	/// number of the system call `pipe`
+	Pipe = 58,
 }
 
 #[thread_local]
@@ -472,6 +474,13 @@ pub extern "C" fn sys_close(fd: i32) -> i32 {
 #[no_mangle]
 pub extern "C" fn sys_dup(fd: i32) -> i32 {
 	let result: i32 = syscall!(SyscallNo::Dup, fd).try_into().unwrap();
+	update_errno!(result);
+	result
+}
+
+#[no_mangle]
+pub extern "C" fn sys_pipe(pipefd: *mut i32) -> i32 {
+	let result: i32 = syscall!(SyscallNo::Pipe, pipefd).try_into().unwrap();
 	update_errno!(result);
 	result
 }

--- a/hermit/src/syscall/riscv64.rs
+++ b/hermit/src/syscall/riscv64.rs
@@ -1,0 +1,182 @@
+use core::arch::asm;
+
+/// This macro can be used to call system functions from user-space
+#[macro_export]
+macro_rules! syscall {
+	($arg0:expr) => {
+		$crate::syscall::riscv64::syscall0($arg0 as u64)
+	};
+
+	($arg0:expr, $arg1:expr) => {
+		$crate::syscall::riscv64::syscall1($arg0 as u64, $arg1 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr) => {
+		$crate::syscall::riscv64::syscall2($arg0 as u64, $arg1 as u64, $arg2 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr) => {
+		$crate::syscall::riscv64::syscall3($arg0 as u64, $arg1 as u64, $arg2 as u64, $arg3 as u64)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr) => {
+		$crate::syscall::riscv64::syscall4(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+		)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
+		$crate::syscall::riscv64::syscall5(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+			$arg5 as u64,
+		)
+	};
+
+	($arg0:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr, $arg6:expr) => {
+		$crate::syscall::riscv64::syscall6(
+			$arg0 as u64,
+			$arg1 as u64,
+			$arg2 as u64,
+			$arg3 as u64,
+			$arg4 as u64,
+			$arg5 as u64,
+			$arg6 as u64,
+		)
+	};
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall0(arg0: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"ecall",
+			in("a7") arg0,
+			lateout("a0") ret,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall1(arg0: u64, arg1: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"ecall",
+			in("a7") arg0,
+			inlateout("a0") arg1 => ret,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall2(arg0: u64, arg1: u64, arg2: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"ecall",
+			in("a7") arg0,
+			inlateout("a0") arg1 => ret,
+			in("a1") arg2,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall3(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"ecall",
+			in("a7") arg0,
+			inlateout("a0") arg1 => ret,
+			in("a1") arg2,
+			in("a2") arg3,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall4(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"ecall",
+			in("a7") arg0,
+			inlateout("a0") arg1 => ret,
+			in("a1") arg2,
+			in("a2") arg3,
+			in("a3") arg4,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall5(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"ecall",
+			in("a7") arg0,
+			inlateout("a0") arg1 => ret,
+			in("a1") arg2,
+			in("a2") arg3,
+			in("a3") arg4,
+			in("a4") arg5,
+			options(preserves_flags)
+		);
+	}
+	ret
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn syscall6(
+	arg0: u64,
+	arg1: u64,
+	arg2: u64,
+	arg3: u64,
+	arg4: u64,
+	arg5: u64,
+	arg6: u64,
+) -> u64 {
+	let ret: u64;
+	unsafe {
+		asm!(
+			"ecall",
+			in("a7") arg0,
+			inlateout("a0") arg1 => ret,
+			in("a1") arg2,
+			in("a2") arg3,
+			in("a3") arg4,
+			in("a4") arg5,
+			in("a5") arg6,
+			options(preserves_flags)
+		);
+	}
+	ret
+}

--- a/hermit/src/syscall/x86_64.rs
+++ b/hermit/src/syscall/x86_64.rs
@@ -56,9 +56,10 @@ macro_rules! syscall {
 #[allow(dead_code)]
 #[inline]
 pub(crate) fn syscall0(arg0: u64) -> u64 {
-	let ret: u64;
+	let mut ret: u64;
 	unsafe {
-		asm!("syscall",
+		asm!(
+			"syscall",
 			inlateout("rax") arg0 => ret,
 			lateout("rcx") _,
 			lateout("r11") _,
@@ -71,9 +72,10 @@ pub(crate) fn syscall0(arg0: u64) -> u64 {
 #[allow(dead_code)]
 #[inline]
 pub(crate) fn syscall1(arg0: u64, arg1: u64) -> u64 {
-	let ret: u64;
+	let mut ret: u64;
 	unsafe {
-		asm!("syscall",
+		asm!(
+			"syscall",
 			inlateout("rax") arg0 => ret,
 			in("rdi") arg1,
 			lateout("rcx") _,
@@ -87,9 +89,10 @@ pub(crate) fn syscall1(arg0: u64, arg1: u64) -> u64 {
 #[allow(dead_code)]
 #[inline]
 pub(crate) fn syscall2(arg0: u64, arg1: u64, arg2: u64) -> u64 {
-	let ret: u64;
+	let mut ret: u64;
 	unsafe {
-		asm!("syscall",
+		asm!(
+			"syscall",
 			inlateout("rax") arg0 => ret,
 			in("rdi") arg1,
 			in("rsi") arg2,
@@ -104,9 +107,10 @@ pub(crate) fn syscall2(arg0: u64, arg1: u64, arg2: u64) -> u64 {
 #[allow(dead_code)]
 #[inline]
 pub(crate) fn syscall3(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> u64 {
-	let ret: u64;
+	let mut ret: u64;
 	unsafe {
-		asm!("syscall",
+		asm!(
+			"syscall",
 			inlateout("rax") arg0 => ret,
 			in("rdi") arg1,
 			in("rsi") arg2,
@@ -122,9 +126,10 @@ pub(crate) fn syscall3(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> u64 {
 #[allow(dead_code)]
 #[inline]
 pub(crate) fn syscall4(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64) -> u64 {
-	let ret: u64;
+	let mut ret: u64;
 	unsafe {
-		asm!("syscall",
+		asm!(
+			"syscall",
 			inlateout("rax") arg0 => ret,
 			in("rdi") arg1,
 			in("rsi") arg2,
@@ -141,10 +146,11 @@ pub(crate) fn syscall4(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64) ->
 #[allow(dead_code)]
 #[inline]
 pub(crate) fn syscall5(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) -> u64 {
-	let ret: u64;
+	let mut ret: u64;
 	unsafe {
-		asm!("syscall",
-			inlateout("rax") arg0 => ret,
+		asm!(
+			"syscall",
+			inlateout("rax") arg0 =>ret,
 			in("rdi") arg1,
 			in("rsi") arg2,
 			in("rdx") arg3,
@@ -169,9 +175,10 @@ pub(crate) fn syscall6(
 	arg5: u64,
 	arg6: u64,
 ) -> u64 {
-	let ret: u64;
+	let mut ret: u64;
 	unsafe {
-		asm!("syscall",
+		asm!(
+			"syscall",
 			inlateout("rax") arg0 => ret,
 			in("rdi") arg1,
 			in("rsi") arg2,

--- a/hermit/src/syscall/x86_64.rs
+++ b/hermit/src/syscall/x86_64.rs
@@ -63,7 +63,7 @@ pub(crate) fn syscall0(arg0: u64) -> u64 {
 			inlateout("rax") arg0 => ret,
 			lateout("rcx") _,
 			lateout("r11") _,
-			options(preserves_flags)
+			options(preserves_flags, nostack)
 		);
 	}
 	ret
@@ -80,7 +80,7 @@ pub(crate) fn syscall1(arg0: u64, arg1: u64) -> u64 {
 			in("rdi") arg1,
 			lateout("rcx") _,
 			lateout("r11") _,
-			options(preserves_flags)
+			options(preserves_flags, nostack)
 		);
 	}
 	ret
@@ -98,7 +98,7 @@ pub(crate) fn syscall2(arg0: u64, arg1: u64, arg2: u64) -> u64 {
 			in("rsi") arg2,
 			lateout("rcx") _,
 			lateout("r11") _,
-			options(preserves_flags)
+			options(preserves_flags, nostack)
 		);
 	}
 	ret
@@ -117,7 +117,7 @@ pub(crate) fn syscall3(arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> u64 {
 			in("rdx") arg3,
 			lateout("rcx") _,
 			lateout("r11") _,
-			options(preserves_flags)
+			options(preserves_flags, nostack)
 		);
 	}
 	ret
@@ -137,7 +137,7 @@ pub(crate) fn syscall4(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64) ->
 			in("r10") arg4,
 			lateout("rcx") _,
 			lateout("r11") _,
-			options(preserves_flags)
+			options(preserves_flags, nostack)
 		);
 	}
 	ret
@@ -158,7 +158,7 @@ pub(crate) fn syscall5(arg0: u64, arg1: u64, arg2: u64, arg3: u64, arg4: u64, ar
 			in("r8") arg5,
 			lateout("rcx") _,
 			lateout("r11") _,
-			options(preserves_flags)
+			options(preserves_flags, nostack)
 		);
 	}
 	ret
@@ -188,7 +188,7 @@ pub(crate) fn syscall6(
 			in("r9") arg6,
 			lateout("rcx") _,
 			lateout("r11") _,
-			options(preserves_flags)
+			options(preserves_flags, nostack)
 		);
 	}
 	ret


### PR DESCRIPTION
In the long term, Hermit will also be usable as a monolithic OS. To prepare for this, an example of calling the system calls `fork` and `spawn_process` are being integrated. In the case of a unikernel, the fork call will return an error (ENOSYS).