### PR TITLE
feat: use kernel's default features

### DIFF
--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -22,19 +22,7 @@ take-static = { version = "0.1", optional = true }
 talc = { version = "4.4", default-features = false, features = ["lock_api"], optional = true  }
 
 [features]
-default = [
-    "acpi",
-    "dhcpv4",
-    "dns",
-    "fsgsbase",
-    "kernel-stack",
-    "pci-ids",
-    "pci",
-    "smp",
-    "tcp",
-    "udp",
-    "virtio-fs",
-]
+default = []
 common-os = ["hermit-abi", "generic_once_cell", "libm", "spinning_top", "take-static", "talc"]
 
 ## Links against libc.a.

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -104,6 +104,7 @@ impl KernelSrc {
 		forward_features(
 			&mut cargo,
 			[
+				"default",
 				"common-os",
 				"mman",
 				"newlib",


### PR DESCRIPTION
This PR makes the wrapper crate just defer the default features to the kernel. Effectively, this means this change in default features:

```diff
 default = [
     "acpi",
     "dhcpv4",
-    "dns",
     "fsgsbase",
     "kernel-stack",
     "pci-ids",
     "pci",
     "smp",
     "tcp",
-    "udp",
     "virtio-fs",
+    "virtio-net",
+    "virtio-vsock",
 ]
```

We can also adjust the kernel features if someone thinks we should.

Kernel CI result: https://github.com/hermit-os/kernel/commit/10515fe47d9f35597540213f6af315c235eb59aa (success).