### PR TITLE
build(deps): upgrade rust-toolchain to nightly-2026-05-05

### DIFF
--- a/benches/netbench/src/config.rs
+++ b/benches/netbench/src/config.rs
@@ -51,6 +51,6 @@ pub struct Config {
 
 impl Config {
 	pub fn address_and_port(&self) -> String {
-		format!("{}:{}", &self.address, &self.port)
+		format!("{}:{}", self.address, self.port)
 	}
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-05-01"
+channel = "nightly-2026-05-05"
 components = [ "rust-src" ]


### PR DESCRIPTION
We can't use nightly-2026-05-01 due to a compiler bug:

```console
$ RUSTFLAGS="-Zinstrument-mcount -Cpasses=ee-instrument<post-inline>" cargo build --target=x86_64-unknown-hermit -Zbuild-std=std,panic_abort --package rftrace-example
thread 'rustc' (1402267) panicked at /rustc-dev/f53b654a8882fd5fc036c4ca7a4ff41ce32497a6/compiler/rustc_codegen_ssa/src/back/linker.rs:228:5:
assertion failed: l.is_cc()
stack backtrace:
   0:     0x7fe8b72767b9 - <<std[664156f38db6df9a]::sys::backtrace::BacktraceLock>::print::DisplayBacktrace as core[703624273cedab6d]::fmt::Display>::fmt
   1:     0x7fe8b7815f08 - core[703624273cedab6d]::fmt::write
   2:     0x7fe8b728d1e6 - <std[664156f38db6df9a]::sys::stdio::unix::Stderr as std[664156f38db6df9a]::io::Write>::write_fmt
   3:     0x7fe8b724c98e - std[664156f38db6df9a]::panicking::default_hook::{closure#0}
   4:     0x7fe8b7269e73 - std[664156f38db6df9a]::panicking::default_hook
   5:     0x7fe8b6260051 - std[664156f38db6df9a]::panicking::update_hook::<alloc[150995461fc6fe17]::boxed::Box<rustc_driver_impl[2526e35b49e1b9f9]::install_ice_hook::{closure#1}>>::{closure#0}
   6:     0x7fe8b726a152 - std[664156f38db6df9a]::panicking::panic_with_hook
   7:     0x7fe8b724ca84 - std[664156f38db6df9a]::panicking::panic_handler::{closure#0}
   8:     0x7fe8b7240f89 - std[664156f38db6df9a]::sys::backtrace::__rust_end_short_backtrace::<std[664156f38db6df9a]::panicking::panic_handler::{closure#0}, !>
   9:     0x7fe8b724e4bd - __rustc[574100d523623398]::rust_begin_unwind
  10:     0x7fe8b3ee8c9c - core[703624273cedab6d]::panicking::panic_fmt
  11:     0x7fe8b512ff02 - core[703624273cedab6d]::panicking::panic
  12:     0x7fe8b610475e - <rustc_codegen_ssa[a425fcc24d8e7b2e]::back::linker::GccLinker as rustc_codegen_ssa[a425fcc24d8e7b2e]::back::linker::Linker>::enable_profiling
  13:     0x7fe8b8dff62e - rustc_codegen_ssa[a425fcc24d8e7b2e]::back::link::add_order_independent_options
  14:     0x7fe8b89f7c0e - rustc_codegen_ssa[a425fcc24d8e7b2e]::back::link::linker_with_args
  15:     0x7fe8b8acda14 - rustc_codegen_ssa[a425fcc24d8e7b2e]::back::link::link_natively
  16:     0x7fe8b8a8212d - rustc_codegen_ssa[a425fcc24d8e7b2e]::back::link::link_binary
  17:     0x7fe8b8a81208 - <rustc_codegen_llvm[363781b12576299c]::LlvmCodegenBackend as rustc_codegen_ssa[a425fcc24d8e7b2e]::traits::backend::CodegenBackend>::link
  18:     0x7fe8b8763c27 - <rustc_interface[952682f9f3d307b7]::queries::Linker>::link
  19:     0x7fe8b89b80aa - rustc_interface[952682f9f3d307b7]::interface::run_compiler::<(), rustc_driver_impl[2526e35b49e1b9f9]::run_compiler::{closure#0}>::{closure#1}
  20:     0x7fe8b899537e - std[664156f38db6df9a]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[952682f9f3d307b7]::util::run_in_thread_with_globals<rustc_interface[952682f9f3d307b7]::util::run_in_thread_pool_with_globals<rustc_interface[952682f9f3d307b7]::interface::run_compiler<(), rustc_driver_impl[2526e35b49e1b9f9]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
  21:     0x7fe8b8995a6d - <std[664156f38db6df9a]::thread::lifecycle::spawn_unchecked<rustc_interface[952682f9f3d307b7]::util::run_in_thread_with_globals<rustc_interface[952682f9f3d307b7]::util::run_in_thread_pool_with_globals<rustc_interface[952682f9f3d307b7]::interface::run_compiler<(), rustc_driver_impl[2526e35b49e1b9f9]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[703624273cedab6d]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  22:     0x7fe8b899686c - <std[664156f38db6df9a]::sys::thread::unix::Thread>::new::thread_start
  23:     0x7fe8b26a71f5 - start_thread
                               at ./nptl/pthread_create.c:442:8
  24:     0x7fe8b27278dc - clone3
                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81:0
  25:                0x0 - <unknown>

error: the compiler unexpectedly panicked. This is a bug

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: please make sure that you have updated to the latest nightly

note: please attach the file at `/home/debian/devel/hermit-rs/rustc-ice-2026-05-08T14_45_58-1402265.txt` to your bug report

note: rustc 1.97.0-nightly (f53b654a8 2026-04-30) running on x86_64-unknown-linux-gnu

note: compiler flags: --crate-type bin -C embed-bitcode=no -C debuginfo=2 -C incremental=[REDACTED] -Z unstable-options -Z instrument-mcount -C passes=ee-instrument<post-inline>

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
end of query stack
error: could not compile `rftrace-example` (bin "rftrace-example")
```