### PR TITLE
fix(httpd): sleep before shutting down

### DIFF
--- a/examples/httpd/src/main.rs
+++ b/examples/httpd/src/main.rs
@@ -1,3 +1,6 @@
+use std::thread;
+use std::time::Duration;
+
 #[cfg(target_os = "hermit")]
 use hermit as _;
 
@@ -19,6 +22,9 @@ fn main() {
 		handle_request(request);
 
 		if cfg!(feature = "ci") {
+			// Wait before shutting down to send response.
+			thread::sleep(Duration::from_secs(1));
+
 			break;
 		}
 	}


### PR DESCRIPTION
Similar to e5f7e2272a689d88344259fceac99b09e72f84ef, we should sleep a bit before exiting to make sure the response is sent to the client.