### PR TITLE
build(deps): update Rust toolchain to nightly-2026-08-01

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-07-01"
+channel = "nightly-2026-08-01"
 components = [ "rust-src" ]


### PR DESCRIPTION
Notably for Hermit apps, this includes:

- https://github.com/rust-lang/rust/pull/158649
- https://github.com/rust-lang/rust/pull/158247