### PR TITLE
feat: add smoltcp-auto-icmp-echo-reply feature

### DIFF
--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -54,6 +54,13 @@ log-release_max_level_info = []
 log-release_max_level_debug = []
 log-release_max_level_trace = []
 
+#! ### Smoltcp Features
+#!
+#! Enables the corresponding feature for the kernel's `smoltcp` crate.
+
+## Automatically reply on an ICMP echo request
+smoltcp-auto-icmp-echo-reply = []
+
 #! ### Kernel Features
 #!
 #! For details, see the kernel [docs].

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -225,6 +225,8 @@ fn forward_features(cargo: &mut Command) {
 		.map(|feature| {
 			if let Some(log_feature) = feature.strip_prefix("log-") {
 				["log/", log_feature].join("")
+			} else if let Some(smoltcp_feature) = feature.strip_prefix("smoltcp-") {
+				["smoltcp/", smoltcp_feature].join("")
 			} else {
 				feature.to_owned()
 			}


### PR DESCRIPTION
This PR adds a `smoltcp-auto-icmp-echo-reply` feature to enable the kernel's `smoltcp/auto-icmp-echo-reply`. This is similar to what we do for the compile-time log filters.

Closes https://github.com/hermit-os/kernel/pull/2616.