### PR TITLE
chore(Cargo.toml): remove deprecated authors field

### DIFF
--- a/benches/alloc_benchmarks/Cargo.toml
+++ b/benches/alloc_benchmarks/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "alloc_benchmarks"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [dependencies]

--- a/benches/micro_benchmarks/Cargo.toml
+++ b/benches/micro_benchmarks/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "micro_benchmarks"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [dependencies]

--- a/benches/multithreaded_benchmark/Cargo.toml
+++ b/benches/multithreaded_benchmark/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "multithreaded_benchmark"
-authors = ["Carl Wachter"]
 edition = "2021"
 
 [dependencies]

--- a/benches/mutex_benchmark/Cargo.toml
+++ b/benches/mutex_benchmark/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "mutex_benchmark"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [target.'cfg(target_os = "hermit")'.dependencies]

--- a/benches/rust-tcp-io-perf/Cargo.toml
+++ b/benches/rust-tcp-io-perf/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 
 name = "rust-tcp-io-perf"
-authors = [
-    "Lorenzo Martini <lmartini@student.ethz.ch>",
-    "Jonathan Klimt <jonathan.klimt@eonerc.rwth-aachen.de>"
-]
 edition = "2021"
 readme = "README.md"
 

--- a/benches/startup_benchmark/Cargo.toml
+++ b/benches/startup_benchmark/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "startup_benchmark"
-authors = ["Carl Wachter"]
 edition = "2021"
 
 [dependencies]

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "dns"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [dependencies]

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "hello_world"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [target.'cfg(target_os = "hermit")'.dependencies]

--- a/examples/hermit-wasm/Cargo.toml
+++ b/examples/hermit-wasm/Cargo.toml
@@ -2,7 +2,6 @@
 name = "hermit-wasm"
 version = "0.1.1"
 edition = "2024"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 repository = "https://github.com/hermit-os/hermit-rs/tree/main/examples/hermit-wasm"
 description = "Running WASM modules inside a lightweight virtual machine"
 readme = "README.md"

--- a/examples/httpd/Cargo.toml
+++ b/examples/httpd/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "httpd"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [dependencies]

--- a/examples/miotcp/Cargo.toml
+++ b/examples/miotcp/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "miotcp"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [dependencies]

--- a/examples/mioudp/Cargo.toml
+++ b/examples/mioudp/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "mioudp"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [dependencies]

--- a/examples/poll/Cargo.toml
+++ b/examples/poll/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "poll"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [dependencies]

--- a/examples/rftrace-example/Cargo.toml
+++ b/examples/rftrace-example/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "rftrace-example"
-authors = ["Martin Kröning <mkroening@posteo.net>"]
 edition = "2021"
 
 [dependencies]

--- a/examples/rusty_demo/Cargo.toml
+++ b/examples/rusty_demo/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "rusty_demo"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>", "Marco Ruppert-Maas <marco.ruppert-maas@studium.fernuni-hagen.de>"]
 edition = "2024"
 
 [dependencies]

--- a/examples/thread_test/Cargo.toml
+++ b/examples/thread_test/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "thread_test"
-authors = ["Marco Ruppert-Maas <marco.ruppert-maas@studium.fernuni-hagen.de>"]
 edition = "2024"
 
 [target.'cfg(target_os = "hermit")'.dependencies]

--- a/examples/tokio-minimal/Cargo.toml
+++ b/examples/tokio-minimal/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "tokio-minimal"
-authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 edition = "2021"
 
 [dependencies]

--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hermit-abi"
 version = "0.5.2"
-authors = ["Stefan Lankes"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Hermit system calls definitions."

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "hermit"
 version = "0.13.2"
-authors = [
-	"Stefan Lankes <slankes@eonerc.rwth-aachen.de>",
-	"Martin Kröning <mkroening@posteo.net>",
-]
 edition = "2021"
 description = "The Hermit unikernel for Rust."
 repository = "https://github.com/hermit-os/hermit-rs"


### PR DESCRIPTION
`package.authors` was deprecated in https://github.com/rust-lang/cargo/pull/15068 and is listed as deprecated in the docs: [The Manifest Format - The Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field)

Also see:
- https://github.com/hermit-os/kernel/pull/2627