### PR TITLE
fix(benches): enable loader feature

### DIFF
--- a/benches/alloc_benchmarks/Cargo.toml
+++ b/benches/alloc_benchmarks/Cargo.toml
@@ -14,4 +14,4 @@ hermit = { path = "../../hermit", default-features = false }
 riscv = "0.16"
 
 [features]
-default = ["hermit/acpi", "hermit/pci"]
+default = ["hermit/acpi", "hermit/loader", "hermit/pci"]

--- a/benches/micro_benchmarks/Cargo.toml
+++ b/benches/micro_benchmarks/Cargo.toml
@@ -20,4 +20,4 @@ riscv = "0.16"
 syscalls = { version = "0.8", default-features = false }
 
 [features]
-default = ["hermit/acpi", "hermit/pci", "hermit/smp"]
+default = ["hermit/acpi", "hermit/loader", "hermit/pci", "hermit/smp"]

--- a/benches/multithreaded_benchmark/Cargo.toml
+++ b/benches/multithreaded_benchmark/Cargo.toml
@@ -10,4 +10,4 @@ hermit_bench_output = "0.1.0"
 hermit = { path = "../../hermit", default-features = false }
 
 [features]
-default = ["hermit/acpi", "hermit/pci", "hermit/smp"]
+default = ["hermit/acpi", "hermit/loader", "hermit/pci", "hermit/smp"]

--- a/benches/mutex_benchmark/Cargo.toml
+++ b/benches/mutex_benchmark/Cargo.toml
@@ -10,4 +10,4 @@ hermit = { path = "../../hermit", default-features = false }
 hermit_bench_output = "0.1.1"
 
 [features]
-default = ["hermit/acpi", "hermit/pci", "hermit/smp"]
+default = ["hermit/acpi", "hermit/loader", "hermit/pci", "hermit/smp"]

--- a/benches/rust-tcp-io-perf/Cargo.toml
+++ b/benches/rust-tcp-io-perf/Cargo.toml
@@ -21,4 +21,4 @@ hermit_bench_output = "0.1.0"
 hermit = { path = "../../hermit", default-features = false }
 
 [features]
-default = ["hermit/acpi", "hermit/pci", "hermit/smp", "hermit/tcp", "hermit/udp"]
+default = ["hermit/acpi", "hermit/loader", "hermit/pci", "hermit/smp", "hermit/tcp", "hermit/udp"]

--- a/benches/startup_benchmark/Cargo.toml
+++ b/benches/startup_benchmark/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 hermit = { path = "../../hermit", default-features = false }
 
 [features]
-default = ["hermit/acpi", "hermit/pci"]
+default = ["hermit/acpi", "hermit/loader", "hermit/pci"]


### PR DESCRIPTION
https://github.com/hermit-os/kernel/pull/2546 broke benching. Since we cannot enable features in the kernel benchmark description, we have to do it here.