### PR TITLE
chore: adapt to new loader 0.5.7 names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --no-install-recommends ipxe-qemu libcap-ng-dev libseccomp-dev ${{ matrix.packages }}
       - name: Download loader
-        run: gh release download --repo hermit-os/loader --pattern hermit-loader-${{ matrix.arch }}
+        run: gh release download --repo hermit-os/loader --pattern 'hermit-loader-${{ matrix.arch }}*'
       - uses: mkroening/rust-toolchain-toml@main
       - uses: mkroening/rust-toolchain-toml@main
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,15 +34,15 @@ jobs:
       run: cp target/x86_64-unknown-hermit/release/rusty_demo .
     - name: Download loader
       run: |
-        gh release download --repo hermit-os/loader --pattern hermit-loader-x86_64
-        gh release download --repo hermit-os/loader --pattern hermit-loader-x86_64-fc
+        gh release download --repo hermit-os/loader --pattern hermit-loader-x86_64-multiboot
+        gh release download --repo hermit-os/loader --pattern hermit-loader-x86_64-linux
         gh release download --repo hermit-os/loader --pattern hermit-loader-x86_64.efi
     - name: Create dockerfile for rusty_demo
       run: |
         cat << END > Dockerfile
         FROM ghcr.io/hermit-os/hermit_env:latest
-        COPY hermit-loader-x86_64 hermit/hermit-loader
-        COPY hermit-loader-x86_64-fc hermit/hermit-loader-fc
+        COPY hermit-loader-x86_64-multiboot hermit/hermit-loader-multiboot
+        COPY hermit-loader-x86_64-linux hermit/hermit-loader-linux
         COPY rusty_demo hermit/rusty_demo
         CMD ["/hermit/rusty_demo"]
         END
@@ -87,8 +87,8 @@ jobs:
       run: |
         cat << END > Dockerfile
         FROM ghcr.io/hermit-os/hermit_env:latest
-        COPY hermit-loader-x86_64 hermit/hermit-loader
-        COPY hermit-loader-x86_64-fc hermit/hermit-loader-fc
+        COPY hermit-loader-x86_64-multiboot hermit/hermit-loader-multiboot
+        COPY hermit-loader-x86_64-linux hermit/hermit-loader-linux
         COPY httpd hermit/httpd
         CMD ["/hermit/httpd"]
         END
@@ -102,8 +102,8 @@ jobs:
       run: |
         cat << END > Dockerfile
         FROM ghcr.io/hermit-os/hermit_env_alpine:latest
-        COPY hermit-loader-x86_64 hermit/hermit-loader
-        COPY hermit-loader-x86_64-fc hermit/hermit-loader-fc
+        COPY hermit-loader-x86_64-multiboot hermit/hermit-loader-multiboot
+        COPY hermit-loader-x86_64-linux hermit/hermit-loader-linux
         COPY httpd hermit/httpd
         CMD ["/hermit/httpd"]
         END
@@ -136,8 +136,8 @@ jobs:
         cat << END > Dockerfile
         FROM ghcr.io/hermit-os/hermit_env:latest
         COPY root root
-        COPY hermit-loader-x86_64 hermit/hermit-loader
-        COPY hermit-loader-x86_64-fc hermit/hermit-loader-fc
+        COPY hermit-loader-x86_64-multiboot hermit/hermit-loader-multiboot
+        COPY hermit-loader-x86_64-linux hermit/hermit-loader-linux
         COPY webserver hermit/webserver
         CMD ["/hermit/webserver"]
         END
@@ -155,8 +155,8 @@ jobs:
       run: |
         cat << END > Dockerfile
         FROM ghcr.io/hermit-os/hermit_env:latest
-        COPY hermit-loader-x86_64 hermit/hermit-loader
-        COPY hermit-loader-x86_64-fc hermit/hermit-loader-fc
+        COPY hermit-loader-x86_64-multiboot hermit/hermit-loader-multiboot
+        COPY hermit-loader-x86_64-linux hermit/hermit-loader-linux
         COPY tls hermit/tls
         CMD ["/hermit/tls"]
         END
@@ -174,8 +174,8 @@ jobs:
       run: |
         cat << END > Dockerfile
         FROM ghcr.io/hermit-os/hermit_env:latest
-        COPY hermit-loader-x86_64 hermit/hermit-loader
-        COPY hermit-loader-x86_64-fc hermit/hermit-loader-fc
+        COPY hermit-loader-x86_64-multiboot hermit/hermit-loader-multiboot
+        COPY hermit-loader-x86_64-linux hermit/hermit-loader-linux
         COPY axum-example hermit/axum-example
         CMD ["/hermit/axum-example"]
         END

--- a/benches/rust-tcp-io-perf/run.sh
+++ b/benches/rust-tcp-io-perf/run.sh
@@ -63,10 +63,10 @@ hermit() {
     # that anything that is ELF is not a Linux kernel, which makes it not process
     # the -initrd argument
 
-    loader="$root_dir"/target/"$rust_arch-unknown-hermit"/release/"$bin"
+    kernel="$root_dir"/target/"$rust_arch-unknown-hermit"/release/"$bin"
     case "$arch" in
-        aarch64*|riscv64) initrd_arg="-device guest-loader,addr=0x48000000,initrd=$loader" ;;
-        x86_64) initrd_arg="-initrd $loader" ;;
+        aarch64*|riscv64) initrd_arg="-device guest-loader,addr=0x48000000,initrd=$kernel" ;;
+        x86_64) initrd_arg="-initrd $kernel" ;;
     esac
 
     sudo "qemu-system-$qemu_arch" -M "$qemu_machine" -cpu host \

--- a/benches/rust-tcp-io-perf/run.sh
+++ b/benches/rust-tcp-io-perf/run.sh
@@ -69,9 +69,15 @@ hermit() {
         x86_64) initrd_arg="-initrd $kernel" ;;
     esac
 
+    case "$arch" in
+        aarch64*) loader_suffix=elf ;;
+        riscv64) loader_suffix=sbi ;;
+        x86_64) loader_suffix=multiboot ;;
+    esac
+
     sudo "qemu-system-$qemu_arch" -M "$qemu_machine" -cpu host \
             -enable-kvm -display none -smp 1 -m 1G -serial stdio \
-            -kernel "$root_dir"/kernel/"hermit-loader-$loader_arch" \
+            -kernel "$root_dir"/kernel/"hermit-loader-$loader_arch-$loader_suffix" \
             $initrd_arg \
             -netdev tap,id=net0,script="$root_dir"/kernel/xtask/hermit-ifup,vhost=on \
             -device virtio-net-pci,netdev=net0,disable-legacy=on \

--- a/examples/hermit-wasm/Makefile
+++ b/examples/hermit-wasm/Makefile
@@ -25,6 +25,6 @@ run: target/x86_64-unknown-hermit/release/wasmi_demo
 		-smp 4 \
 		-m 1G \
 		-device isa-debug-exit,iobase=0xf4,iosize=0x04 \
-		-kernel hermit-loader-x86_64 \
+		-kernel hermit-loader-x86_64-multiboot \
 		-initrd target/x86_64-unknown-hermit/release/wasmi-demo \
 		-netdev user,id=u1,hostfwd=tcp::3000-:3000 -device virtio-net-pci,netdev=u1,disable-legacy=on,packed=on,mq=on

--- a/examples/hermit-wasm/README.md
+++ b/examples/hermit-wasm/README.md
@@ -44,7 +44,7 @@ virtiofsd --socket-path=./vhostqemu --shared-dir ./target/wasm32-wasip1/release 
 
 Start _Hermit-WASM_ within the hypervisor Qemu as followed:
 ```sh
-qemu-system-aarch64 --enable-kvm -display none -serial stdio -kernel hermit-loader-x86_64 -initrd target/aarch64-unknown-hermit/release/hermit-wasm -append "-- /root/wasm-test.wasm" -cpu host -device isa-debug-exit,iobase=0xf4,iosize=0x04 -smp 1 -m 2G -global virtio-mmio.force-legacy=off -chardev socket,id=char0,path=./vhostqemu -device vhost-user-fs-pci,queue-size=1024,packed=on,chardev=char0,tag=root -object memory-backend-file,id=mem,size=1024M,mem-path=/dev/shm,share=on -numa node,memdev=mem
+qemu-system-aarch64 --enable-kvm -display none -serial stdio -kernel hermit-loader-x86_64-multiboot -initrd target/aarch64-unknown-hermit/release/hermit-wasm -append "-- /root/wasm-test.wasm" -cpu host -device isa-debug-exit,iobase=0xf4,iosize=0x04 -smp 1 -m 2G -global virtio-mmio.force-legacy=off -chardev socket,id=char0,path=./vhostqemu -device vhost-user-fs-pci,queue-size=1024,packed=on,chardev=char0,tag=root -object memory-backend-file,id=mem,size=1024M,mem-path=/dev/shm,share=on -numa node,memdev=mem
 ```
 
 As alternative, [uhyve](https://github.com/hermit-os/uhyve) can be used, which is a minimal hypervisor for Hermit and offers direct access to a local directory. Consequently, uhyve doesn't depend on _virtiofsd_. In the following example, a local file is mounted to _/root/wasm-test.wasm_.


### PR DESCRIPTION
See https://github.com/hermit-os/loader/releases/tag/v0.5.7

Depends on https://github.com/hermit-os/kernel/pull/2660.