### PR TITLE
fix(build.rs): don't unset RUSTC_BOOTSTRAP

### DIFF
--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -238,7 +238,9 @@ fn cargo() -> Command {
 	// Remove rust-toolchain-specific environment variables from kernel cargo
 	cargo.env_remove("LD_LIBRARY_PATH");
 	env::vars()
-		.filter(|(key, _value)| key.starts_with("CARGO") || key.starts_with("RUST"))
+		.filter(|(key, _value)| {
+			key.starts_with("CARGO") || key.starts_with("RUST") && key != "RUSTC_BOOTSTRAP"
+		})
 		.for_each(|(key, _value)| {
 			cargo.env_remove(&key);
 		});


### PR DESCRIPTION
If somebody has set this to opt in to using a stable feature as if it's a nightly compiler, they probably want it to propagate to the child Cargo builds that require unstable features!