### PR TITLE
fix: Enable loader support in published rusty_demo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         username: hermit-os
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build demo
-      run: cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit -p rusty_demo --release
+      run: cargo build -Zbuild-std=std,panic_abort --target x86_64-unknown-hermit -p rusty_demo --features hermit/loader --release
     - name: Copy demo out of target dir
       run: cp target/x86_64-unknown-hermit/release/rusty_demo .
     - name: Download loader


### PR DESCRIPTION
This is an oversight from https://github.com/hermit-os/hermit-rs/commit/7ff07a27d07744c9e93a0357450e0024e73a139a

See
- https://github.com/hermit-os/runh/pull/556